### PR TITLE
API 프록시 설정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,20 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
   },
 
+  // proxy 설정
+  async rewrites() {
+    const isDevelopment = process.env.NODE_ENV === "development";
+
+    if (!isDevelopment) return [];
+
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL}:8080/:path*`,
+      },
+    ];
+  },
+
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/i,

--- a/src/api/_base/axios/authApi.ts
+++ b/src/api/_base/axios/authApi.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
+import getBaseURL from "./getBaseURL";
 
 const authApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: getBaseURL(),
   withCredentials: true,
   timeout: 5000,
 });

--- a/src/api/_base/axios/getBaseURL.ts
+++ b/src/api/_base/axios/getBaseURL.ts
@@ -1,0 +1,9 @@
+const getBaseURL = () => {
+  const isDevelopment = process.env.NODE_ENV === "development";
+
+  if (isDevelopment) return "/api";
+
+  return process.env.NEXT_PUBLIC_API_URL;
+};
+
+export default getBaseURL;

--- a/src/api/_base/axios/publicApi.ts
+++ b/src/api/_base/axios/publicApi.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
+import getBaseURL from "./getBaseURL";
 
 const publicApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: getBaseURL(),
   timeout: 5000,
 });
 


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- #286
  <!-- 또는 issue #이슈번호 -->

## 작업 내용
백엔드와 프론트의 도메인 차이로 인해 인가 API 호출 시 쿠키 전달 실패 확인(SameSite)
그에 따라 Next.js의 프록시를 백엔드 배포 서버로 두어, 같은 출처로 쿠키를 관리하게 프록시 설정을 진행했습니다.

또한 개발 환경에서만 프록시가 적용되어야 함으로써 환경 변수를 사용한 프록시/BaseURL 조건 분기 설정을 진행했습니다.

## 참고 사항
실제 API 연동 작업을 위해 useAppQuery, useAppMutation을 사용하실 때 url에 '/report', '/notice', 'auth/login'으로 사용하시면 개발/프로덕션 환경에 따라 프록시 적용이 자동으로 처리되어 API가 요청됩니다.
머지 후 기존 사용하시던 API 연동 코드에서 이와 다르게 처리되어 있는 부분이 있다면 수정 필요합니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
