### PR TITLE
게시글 수정 페이지, 즐겨찾기 기능 등 QA 수정

### DIFF
--- a/src/api/fetch/post/api/useDeleteFavorites.ts
+++ b/src/api/fetch/post/api/useDeleteFavorites.ts
@@ -44,8 +44,11 @@ export const useDeletePostFavorites = (id: number) => {
 
         return { previous };
       },
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["/users/me/favorites"] });
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["/users/me/favorites"] }),
+          queryClient.invalidateQueries({ queryKey: ["posts"] }),
+        ]);
         addToast("즐겨찾기가 삭제되었어요.", "success");
       },
       onError: (_error, _variables, context) => {

--- a/src/api/fetch/post/api/usePostFavorites.ts
+++ b/src/api/fetch/post/api/usePostFavorites.ts
@@ -43,8 +43,11 @@ export const usePostFavorites = (id: number) => {
 
         return { previous };
       },
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["/users/me/favorites"] });
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["/users/me/favorites"] }),
+          queryClient.invalidateQueries({ queryKey: ["posts"] }),
+        ]);
         addToast("즐겨찾기가 등록되었어요.", "success");
       },
       onError: (_error, _variables, context) => {
@@ -58,7 +61,6 @@ export const usePostFavorites = (id: number) => {
       },
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey });
-        queryClient.invalidateQueries({ queryKey: ["posts"] });
       },
     }
   );

--- a/src/api/fetch/post/api/usePostPosts.ts
+++ b/src/api/fetch/post/api/usePostPosts.ts
@@ -26,7 +26,9 @@ export const usePostPosts = () => {
       ]);
 
       addToast("게시글이 등록되었습니다.", "success");
-      sessionStorage.setItem("showManualPopup", "true");
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem("showManualPopup", "true");
+      }
       setShowManualPopup(true);
       useBetaTestFeedbackStore.getState().openBetaTestModal();
       router.replace(`/list/${data.result.id}`);

--- a/src/api/fetch/post/api/usePostPosts.ts
+++ b/src/api/fetch/post/api/usePostPosts.ts
@@ -14,11 +14,17 @@ export const usePostPosts = () => {
   const { setShowManualPopup } = useWriteFlowStore();
 
   return useAppMutation<FormData, PostPostsWriteResponse>("auth", "/posts", "post", {
-    onSuccess: (data, variables) => {
+    onSuccess: async (data, variables) => {
       if (variables.has("tempPostId")) {
         queryClient.invalidateQueries({ queryKey: ["temp-post"] });
       }
-      queryClient.invalidateQueries({ queryKey: ["/users/me/posts"] });
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["posts"] }),
+        queryClient.invalidateQueries({ queryKey: ["/users/me/posts"] }),
+        queryClient.invalidateQueries({ queryKey: ["similar"] }),
+      ]);
+
       addToast("게시글이 등록되었습니다.", "success");
       sessionStorage.setItem("showManualPopup", "true");
       setShowManualPopup(true);

--- a/src/app/(route)/list/[id]/_components/ClientDetail/ClientDetail.tsx
+++ b/src/app/(route)/list/[id]/_components/ClientDetail/ClientDetail.tsx
@@ -72,6 +72,7 @@ const ClientDetail = ({ id, isLoggedIn }: ClientDetailProps) => {
   }
 
   const { isMine, postUserInformation } = data.result;
+  const similarTitle = data.result.postType === "LOST" ? "비슷한 제보글" : "비슷한 분실물";
 
   return (
     <>
@@ -103,8 +104,8 @@ const ClientDetail = ({ id, isLoggedIn }: ClientDetailProps) => {
           onCommentLoadMore={() => fetchNextPage()}
         />
 
-        <ErrorBoundary fallback={<ErrorSimilarSection postId={id} />}>
-          <SimilarItemsSection postId={id} />
+        <ErrorBoundary fallback={<ErrorSimilarSection postId={id} title={similarTitle} />}>
+          <SimilarItemsSection postId={id} title={similarTitle} />
         </ErrorBoundary>
 
         <PostInputComment postId={id} isLoggedIn={isLoggedIn} />

--- a/src/app/(route)/list/[id]/_components/SimilarItemsSection/SimilarItemsSection.tsx
+++ b/src/app/(route)/list/[id]/_components/SimilarItemsSection/SimilarItemsSection.tsx
@@ -4,9 +4,10 @@ import { SimilarItemsList } from "../_internal";
 
 interface SimilarItemsSectionProps {
   postId: number;
+  title?: string;
 }
 
-const SimilarItemsSection = ({ postId }: SimilarItemsSectionProps) => {
+const SimilarItemsSection = ({ postId, title = "비슷한 분실물" }: SimilarItemsSectionProps) => {
   const { data: similarData } = useGetSimilar({ postId });
 
   if (!similarData?.result || similarData.result.length === 0) return null;
@@ -15,7 +16,7 @@ const SimilarItemsSection = ({ postId }: SimilarItemsSectionProps) => {
     <>
       <hr className="w-full border-neutral-normal-default" />
       <section className="flex flex-col gap-4 py-[18px] pl-5">
-        <h2 className="text-h2-medium text-flatGray-900">비슷한 분실물</h2>
+        <h2 className="text-h2-medium text-flatGray-900">{title}</h2>
 
         <Suspense fallback={null}>
           <SimilarItemsList data={similarData?.result} />

--- a/src/app/(route)/list/[id]/_components/_internal/ErrorSimilarSection/ErrorSimilarSection.tsx
+++ b/src/app/(route)/list/[id]/_components/_internal/ErrorSimilarSection/ErrorSimilarSection.tsx
@@ -1,7 +1,13 @@
 import { Button, Icon } from "@/components/common";
 import { useQueryClient } from "@tanstack/react-query";
 
-const ErrorSimilarSection = ({ postId }: { postId: number }) => {
+const ErrorSimilarSection = ({
+  postId,
+  title = "비슷한 분실물",
+}: {
+  postId: number;
+  title?: string;
+}) => {
   const queryClient = useQueryClient();
 
   const handleRefresh = () => {
@@ -12,7 +18,7 @@ const ErrorSimilarSection = ({ postId }: { postId: number }) => {
     <>
       <hr className="w-full border-neutral-normal-default" />
       <div className="flex flex-col gap-3 py-[18px]">
-        <h2 className="pl-5 text-h2-medium text-flatGray-900">비슷한 분실물</h2>
+        <h2 className="pl-5 text-h2-medium text-flatGray-900">{title}</h2>
 
         <div className="space-y-[18px] py-[10px] flex-col-center">
           <Icon name="ErrorSimilarSection" size={38} />

--- a/src/app/(route)/list/[id]/_components/_internal/SimilarItemsList/SimilarItemsList.test.tsx
+++ b/src/app/(route)/list/[id]/_components/_internal/SimilarItemsList/SimilarItemsList.test.tsx
@@ -2,41 +2,40 @@ import { render, screen } from "@testing-library/react";
 import SimilarItemsList from "./SimilarItemsList";
 import { MOCK_SIMILAR_POST_ITEMS } from "@/mock/data";
 
-jest.mock("@/components/common/ListItemImage/ListItemImage", () => {
-  return {
-    __esModule: true,
-    default: ({ src, alt, size }: { src: string; alt: string; size: number }) => (
-      <img data-testid="list-item-image" src={src} alt={alt} width={size} height={size} />
-    ),
-  };
-});
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return <img {...props} alt={props.alt} />;
+  },
+}));
 
-describe("비슷한 분실물 아이템", () => {
-  it("비슷한 분실물 아이템 이미지가 렌더링되어야 한다.", () => {
+describe("비슷한 게시글 리스트 아이템", () => {
+  it("썸네일 이미지가 있을 때 이미지가 렌더링되어야 한다.", () => {
     render(<SimilarItemsList data={[MOCK_SIMILAR_POST_ITEMS]} />);
 
-    const similarItemElement = screen.getByTestId("list-item-image");
-    expect(similarItemElement).toBeInTheDocument();
+    const image = screen.getByAltText(MOCK_SIMILAR_POST_ITEMS.title);
+    expect(image).toBeInTheDocument();
   });
 
   it("제목이 렌더링되어야 한다.", () => {
     render(<SimilarItemsList data={[MOCK_SIMILAR_POST_ITEMS]} />);
 
-    const similarItemElement = screen.getByText("아이폰 15 분실");
-    expect(similarItemElement).toBeInTheDocument();
+    const titleElement = screen.getByText(MOCK_SIMILAR_POST_ITEMS.title);
+    expect(titleElement).toBeInTheDocument();
   });
 
-  it("위치가 렌더링되어야 한다.", () => {
+  it("날짜가 렌더링되어야 한다.", () => {
     render(<SimilarItemsList data={[MOCK_SIMILAR_POST_ITEMS]} />);
 
-    const similarItemElement = screen.getByText(/서울시/);
-    expect(similarItemElement).toBeInTheDocument();
+    const dateElement = screen.getByText(/2026.02.15/);
+    expect(dateElement).toBeInTheDocument();
   });
 
-  it("시간이 렌더링되어야 한다.", () => {
-    render(<SimilarItemsList data={[MOCK_SIMILAR_POST_ITEMS]} />);
+  it("이미지가 없을 경우 대체 아이콘이 렌더링되어야 한다.", () => {
+    const noImageData = { ...MOCK_SIMILAR_POST_ITEMS, thumbnailImageUrl: "" };
+    render(<SimilarItemsList data={[noImageData]} />);
 
-    const similarItemElement = screen.getByText("2026.02.15");
-    expect(similarItemElement).toBeInTheDocument();
+    const iconElement = screen.getByTestId("icon-LogoCharacter");
+    expect(iconElement).toBeInTheDocument();
   });
 });

--- a/src/app/(route)/list/[id]/_components/_internal/SimilarItemsList/SimilarItemsList.tsx
+++ b/src/app/(route)/list/[id]/_components/_internal/SimilarItemsList/SimilarItemsList.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
+import Image from "next/image";
 import { SimilarDataItem } from "@/api/fetch/post";
-import { Icon, ListItemImage } from "@/components/common";
-import { IconName } from "@/components/common/Icon/Icon";
-import { formatCappedNumber, formatDate } from "@/utils";
+import { formatDate } from "@/utils";
+import { Icon } from "@/components/common";
 
 const SimilarItemsList = ({ data }: { data: SimilarDataItem[] }) => {
   return (
@@ -10,8 +10,8 @@ const SimilarItemsList = ({ data }: { data: SimilarDataItem[] }) => {
       tabIndex={0}
       className="hide-scrollbar flex snap-x snap-mandatory gap-4 overflow-x-auto scroll-smooth"
     >
-      {data.map((post) => (
-        <SimilarItem key={post.postId} data={post} />
+      {data.map((item) => (
+        <SimilarItem key={item.postId} data={item} />
       ))}
     </ul>
   );
@@ -24,45 +24,35 @@ interface SimilarItemProps {
 }
 
 const SimilarItem = ({ data }: SimilarItemProps) => {
-  const { title, thumbnailImageUrl, address, favoriteStatus, createdAt, postId } = data;
-
-  const IconList: { name: IconName; value: number; ariaLabel: string }[] = [
-    {
-      name: "Eye",
-      value: data.viewCount,
-      ariaLabel: "조회수",
-    },
-    {
-      name: favoriteStatus ? "StarFilled" : "Star",
-      value: data.favoriteCount,
-      ariaLabel: "즐겨찾기",
-    },
-  ];
+  const { title, thumbnailImageUrl, createdAt, postId } = data;
 
   return (
     <li className="snap-start">
-      <Link href={`/list/${postId}`} className="flex flex-col items-start justify-center gap-3">
-        <ListItemImage src={thumbnailImageUrl} alt="" category={data.category} size={126} />
-
-        <div className="flex flex-col gap-[3px]">
-          <p className="text-body1-semibold text-layout-header-default">{title}</p>
-          <p className="block text-body2-regular text-layout-body-default">
-            <span className="after:mx-1 after:content-['·']">{address}</span>
-            <time dateTime={createdAt}>{formatDate(createdAt)}</time>
-          </p>
+      <Link
+        href={`/list/${postId}`}
+        className="flex h-[120px] w-[124px] flex-col overflow-hidden rounded-[16px] border border-divider-default bg-white"
+      >
+        <div className="flex h-[76px] w-[124px] items-center justify-center bg-fill-neutralInversed-normal-preesed">
+          {thumbnailImageUrl ? (
+            <Image
+              src={thumbnailImageUrl}
+              alt={title}
+              width={124}
+              height={76}
+              className="h-[76px] w-[124px] object-cover"
+            />
+          ) : (
+            <Icon name="LogoCharacter" size={65} data-testid="icon-LogoCharacter" />
+          )}
         </div>
 
-        <ul className="flex items-center gap-2">
-          {IconList.map((icon, index) => (
-            <li key={index} className="flex items-center gap-1">
-              <Icon name={icon.name} size={18} className="text-flatGray-100" />
-              <span className="sr-only">{icon.ariaLabel}</span>
-              <span className="text-caption1-regular text-neutral-normal-placeholder">
-                {formatCappedNumber(icon.value)}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <div className="flex flex-col gap-1 px-3 pb-2 pt-[6px]">
+          <p className="text-caption1-semibold text-layout-header-default u-ellipsis">{title}</p>
+
+          <time dateTime={createdAt} className="text-caption2-regular text-layout-body-default">
+            {formatDate(createdAt)}
+          </time>
+        </div>
       </Link>
     </li>
   );

--- a/src/app/(route)/write/post/_components/WriteForm/WriteForm.tsx
+++ b/src/app/(route)/write/post/_components/WriteForm/WriteForm.tsx
@@ -18,7 +18,8 @@ const WriteForm = ({ title }: { title: string }) => {
     onConfirmNoImageSubmit,
     onCancelSubmit,
   } = usePostWriteSubmit({ methods });
-  const isSubmitDisabled = !canSubmit(values) || isPosting;
+
+  const isSubmitDisabled = !canSubmit || isPosting;
 
   return (
     <>

--- a/src/app/(route)/write/post/_components/_internal/ContentSection/ContentSection.test.tsx
+++ b/src/app/(route)/write/post/_components/_internal/ContentSection/ContentSection.test.tsx
@@ -1,21 +1,43 @@
 import { render, screen } from "@testing-library/react";
 import ContentSection from "./ContentSection";
 
-const registerMock = jest.fn(() => ({ name: "content" }));
-
 jest.mock("@/components/common", () => ({
   RequiredText: () => <span data-testid="required-text">*</span>,
 }));
 
+let mockFieldValue = "";
+
 jest.mock("react-hook-form", () => ({
   useFormContext: () => ({
-    register: registerMock,
     control: {},
   }),
-  useWatch: jest.fn(),
+  Controller: ({
+    render: renderProp,
+  }: {
+    render: Function;
+    name: string;
+    control: object;
+    rules?: object;
+  }) => {
+    return renderProp({
+      field: {
+        name: "content",
+        value: mockFieldValue,
+        onChange: jest.fn(),
+        onBlur: jest.fn(),
+        ref: jest.fn(),
+      },
+      fieldState: {},
+      formState: {},
+    });
+  },
 }));
 
 describe("ContentSection", () => {
+  beforeEach(() => {
+    mockFieldValue = "";
+  });
+
   it("내용 입력 섹션이 렌더링되어야 한다", () => {
     render(<ContentSection />);
     expect(screen.getByText("내용을 입력해 주세요.")).toBeInTheDocument();
@@ -27,13 +49,10 @@ describe("ContentSection", () => {
     expect(screen.getByTestId("required-text")).toBeInTheDocument();
   });
 
-  it("textarea가 존재하고 placeholder 속성을 가져야 한다", () => {
+  it("textarea가 존재해야 한다", () => {
     render(<ContentSection />);
-
     const textarea = screen.getByRole("textbox");
-
     expect(textarea).toBeInTheDocument();
-    expect(textarea).toHaveAttribute("placeholder", " ");
   });
 
   it("textarea의 rows 기본값은 5이어야 한다", () => {
@@ -42,14 +61,10 @@ describe("ContentSection", () => {
     expect(textarea).toHaveAttribute("rows", "5");
   });
 
-  it("register가 올바른 유효성 검사 옵션과 함께 호출되어야 한다", () => {
+  it("값이 있으면 플레이스홀더 라벨이 사라져야 한다", () => {
+    mockFieldValue = "테스트 내용";
     render(<ContentSection />);
-    expect(registerMock).toHaveBeenCalledWith("content", {
-      required: "내용을 입력해주세요.",
-      maxLength: {
-        value: 500,
-        message: "내용은 500자 이내로 입력해주세요.",
-      },
-    });
+    const labelText = screen.queryByText("내용을 입력해 주세요.");
+    expect(labelText).not.toBeInTheDocument();
   });
 });

--- a/src/app/(route)/write/post/_components/_internal/ContentSection/ContentSection.tsx
+++ b/src/app/(route)/write/post/_components/_internal/ContentSection/ContentSection.tsx
@@ -1,52 +1,52 @@
 import { cn } from "@/utils";
 import { RequiredText } from "@/components/common";
-import { useFormContext, useWatch } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 import { PostWriteFormValues } from "../../../_types/PostWriteType";
 
 const ContentSection = () => {
-  const { register, control } = useFormContext<PostWriteFormValues>();
-  const contentValue = useWatch({ control, name: "content" });
+  const { control } = useFormContext<PostWriteFormValues>();
 
   return (
     <section className="flex-1 border-b border-flatGray-50 px-5 py-6">
-      <div className="relative">
-        <textarea
-          id="content"
-          rows={5}
-          placeholder=" "
-          maxLength={500}
-          className={cn(
-            "min-h-[200px] w-full resize-none py-1 text-body1-medium text-neutral-strong-default",
-            "peer placeholder:text-body2-regular placeholder:text-neutral-normal-placeholder focus:outline-none"
-          )}
-          {...register("content", {
-            required: "내용을 입력해주세요.",
-            maxLength: {
-              value: 500,
-              message: "내용은 500자 이내로 입력해주세요.",
-            },
-          })}
-        />
+      <Controller
+        control={control}
+        name="content"
+        rules={{
+          required: "내용을 입력해주세요.",
+          maxLength: {
+            value: 500,
+            message: "내용은 500자 이내로 입력해주세요.",
+          },
+        }}
+        render={({ field }) => (
+          <div className="relative">
+            <textarea
+              {...field}
+              id="content"
+              rows={5}
+              maxLength={500}
+              className={cn(
+                "min-h-[200px] w-full resize-none py-1 text-body1-medium text-neutral-strong-default",
+                "peer focus:outline-none"
+              )}
+            />
 
-        {!contentValue && (
-          <div
-            className={cn(
-              "pointer-events-none absolute left-0 top-1",
-              "peer-placeholder-shown:opacity-100 peer-[&:not(:placeholder-shown)]:opacity-0"
+            {!field.value && (
+              <div className={cn("pointer-events-none absolute left-0 top-1")}>
+                <p className="text-body1-medium text-flatGray-400">
+                  내용을 입력해 주세요. <RequiredText />
+                </p>
+                <p className="mt-7 text-body2-regular text-neutral-normal-placeholder">
+                  분실/발견 날짜, 물건 종류, 물건의 특징 등 유실물 찾기에 도움이 되는 내용을 작성해
+                  주세요. <br />
+                  저작권과 관련된 내용은 반드시 출처를 표기해야 하며, 의심스러운 글을 작성할 경우
+                  제재 조치를 받을 수 있습니다.
+                </p>
+              </div>
             )}
-          >
-            <p className="text-body1-medium text-flatGray-400">
-              내용을 입력해 주세요. <RequiredText />
-            </p>
-            <p className="mt-7 text-body2-regular text-neutral-normal-placeholder">
-              분실/발견 날짜, 물건 종류, 물건의 특징 등 유실물 찾기에 도움이 되는 내용을 작성해
-              주세요. <br />
-              저작권과 관련된 내용은 반드시 출처를 표기해야 하며, 의심스러운 글을 작성할 경우 제재
-              조치를 받을 수 있습니다.
-            </p>
           </div>
         )}
-      </div>
+      />
     </section>
   );
 };

--- a/src/app/(route)/write/post/_components/_internal/TitleSection/TitleSection.test.tsx
+++ b/src/app/(route)/write/post/_components/_internal/TitleSection/TitleSection.test.tsx
@@ -1,50 +1,58 @@
 import { render, screen } from "@testing-library/react";
 import TitleSection from "./TitleSection";
-import { useWatch } from "react-hook-form";
-
-const registerMock = jest.fn(() => ({ name: "title" }));
 
 jest.mock("@/components/common", () => ({
   RequiredText: () => <span data-testid="required-text">*</span>,
 }));
 
+const mockOnChange = jest.fn();
+let mockFieldValue = "";
+
 jest.mock("react-hook-form", () => ({
   useFormContext: () => ({
-    register: registerMock,
     control: {},
   }),
-  useWatch: jest.fn(),
+  Controller: ({
+    render: renderProp,
+    rules,
+  }: {
+    render: Function;
+    rules?: object;
+    name: string;
+    control: object;
+  }) => {
+    return renderProp({
+      field: {
+        name: "title",
+        value: mockFieldValue,
+        onChange: mockOnChange,
+        onBlur: jest.fn(),
+        ref: jest.fn(),
+      },
+      fieldState: {},
+      formState: {},
+    });
+  },
 }));
 
 describe("TitleSection", () => {
+  beforeEach(() => {
+    mockFieldValue = "";
+    mockOnChange.mockClear();
+  });
+
   it("제목 입력 섹션이 렌더링되어야 한다", () => {
-    (useWatch as jest.Mock).mockReturnValue("");
     render(<TitleSection />);
     expect(screen.getByText("제목을 입력해 주세요.")).toBeInTheDocument();
   });
 
-  it("제목 입력 input이 존재하고 placeholder가 설정되어 있어야 한다", () => {
-    (useWatch as jest.Mock).mockReturnValue("");
+  it("제목 입력 input이 존재해야 한다", () => {
     render(<TitleSection />);
-
-    const input = screen.getByPlaceholderText("제목을 입력해 주세요.");
+    const input = screen.getByRole("textbox");
     expect(input).toBeInTheDocument();
   });
 
-  it("register가 올바른 유효성 검사 옵션과 함께 호출되어야 한다", () => {
-    (useWatch as jest.Mock).mockReturnValue("");
-    render(<TitleSection />);
-    expect(registerMock).toHaveBeenCalledWith(
-      "title",
-      expect.objectContaining({
-        required: "제목을 입력해 주세요.",
-        maxLength: { value: 50, message: "제목은 50자 이내로 입력해 주세요." },
-      })
-    );
-  });
-
   it("라벨 텍스트와 RequiredText가 함께 표시되어야 한다", () => {
-    (useWatch as jest.Mock).mockReturnValue("");
     render(<TitleSection />);
 
     const labelText = screen.getByText("제목을 입력해 주세요.");
@@ -55,7 +63,7 @@ describe("TitleSection", () => {
   });
 
   it("사용자가 입력을 시작하여 값이 생기면 라벨이 사라져야 한다", async () => {
-    (useWatch as jest.Mock).mockReturnValue("테스트 제목");
+    mockFieldValue = "테스트 제목";
     render(<TitleSection />);
 
     const labelText = screen.queryByText("제목을 입력해 주세요.");

--- a/src/app/(route)/write/post/_components/_internal/TitleSection/TitleSection.tsx
+++ b/src/app/(route)/write/post/_components/_internal/TitleSection/TitleSection.tsx
@@ -1,41 +1,45 @@
 import { cn } from "@/utils";
 import { RequiredText } from "@/components/common";
-import { useFormContext, useWatch } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 import { PostWriteFormValues } from "../../../_types/PostWriteType";
 
 const TitleSection = () => {
-  const { register, control } = useFormContext<PostWriteFormValues>();
-  const titleValue = useWatch({ control, name: "title" });
+  const { control } = useFormContext<PostWriteFormValues>();
 
   return (
     <section className="relative flex items-center justify-between border-b border-flatGray-50 px-5 py-6">
-      <div className="relative w-full">
-        <input
-          type="text"
-          id="title"
-          placeholder="제목을 입력해 주세요."
-          maxLength={50}
-          className="peer w-full bg-transparent text-body1-medium text-neutral-normal-default placeholder-transparent outline-none placeholder:text-flatGray-400"
-          {...register("title", {
-            required: "제목을 입력해 주세요.",
-            maxLength: {
-              value: 50,
-              message: "제목은 50자 이내로 입력해 주세요.",
-            },
-          })}
-        />
-        {!titleValue && (
-          <span
-            className={cn(
-              "absolute left-0 top-1/2 -translate-y-1/2",
-              "pointer-events-none text-body1-medium text-neutral-normal-placeholder",
-              "peer-placeholder-shown:opacity-100 peer-[&:not(:placeholder-shown)]:opacity-0"
+      <Controller
+        control={control}
+        name="title"
+        rules={{
+          required: "제목을 입력해 주세요.",
+          maxLength: {
+            value: 50,
+            message: "제목은 50자 이내로 입력해 주세요.",
+          },
+        }}
+        render={({ field }) => (
+          <div className="relative w-full">
+            <input
+              {...field}
+              type="text"
+              id="title"
+              maxLength={50}
+              className="peer w-full bg-transparent text-body1-medium text-neutral-normal-default outline-none"
+            />
+            {!field.value && (
+              <span
+                className={cn(
+                  "absolute left-0 top-1/2 -translate-y-1/2",
+                  "pointer-events-none text-body1-medium text-neutral-normal-placeholder"
+                )}
+              >
+                제목을 입력해 주세요. <RequiredText />
+              </span>
             )}
-          >
-            제목을 입력해 주세요. <RequiredText />
-          </span>
+          </div>
         )}
-      </div>
+      />
     </section>
   );
 };

--- a/src/app/(route)/write/post/_hooks/usePostEditSubmit/usePostEditSubmit.ts
+++ b/src/app/(route)/write/post/_hooks/usePostEditSubmit/usePostEditSubmit.ts
@@ -11,19 +11,19 @@ interface UsePostEditSubmitProps {
 }
 
 const usePostEditSubmit = ({ postId, methods }: UsePostEditSubmitProps) => {
-  const { lat, lng, address, radius, postType, clearLocation } = useWriteStore();
+  const { lat, lng, fullAddress, radius, postType, clearLocation } = useWriteStore();
 
   useEffect(() => {
     methods.setValue("postType", postType ?? "", { shouldValidate: true });
-    methods.setValue("address", address ?? "", { shouldValidate: true });
+    methods.setValue("address", fullAddress ?? "", { shouldValidate: true });
     methods.setValue("latitude", lat ?? null, { shouldValidate: true });
     methods.setValue("longitude", lng ?? null, { shouldValidate: true });
     methods.setValue("radius", radius ?? null, { shouldValidate: true });
-  }, [postType, address, lat, lng, radius, methods]);
+  }, [postType, fullAddress, lat, lng, radius, methods]);
 
   const canSubmit = (values: PostWriteFormValues) => {
     if (!postType) return false;
-    if (!address) return false;
+    if (!fullAddress) return false;
     if (lat == null || lng == null || radius == null) return false;
     if (!values.category) return false;
     if (!values.title || !values.content) return false;
@@ -35,7 +35,7 @@ const usePostEditSubmit = ({ postId, methods }: UsePostEditSubmitProps) => {
 
   const toFormData = (values: PostWriteFormValues): FormData | null => {
     if (!postType || !values.category) return null;
-    if (!address || lat == null || lng == null || radius == null) return null;
+    if (!fullAddress || lat == null || lng == null || radius == null) return null;
 
     const firstImage = values.images[0];
     const thumbnailImageId = firstImage?.id ?? null;
@@ -45,7 +45,7 @@ const usePostEditSubmit = ({ postId, methods }: UsePostEditSubmitProps) => {
       title: values.title,
       category: values.category,
       content: values.content,
-      address: address,
+      address: fullAddress,
       latitude: lat,
       longitude: lng,
       radius: radius,

--- a/src/app/(route)/write/post/_hooks/usePostWriteSubmit/usePostWriteSubmit.ts
+++ b/src/app/(route)/write/post/_hooks/usePostWriteSubmit/usePostWriteSubmit.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { UseFormReturn } from "react-hook-form";
+import { useEffect, useState, useMemo } from "react";
+import { UseFormReturn, useWatch } from "react-hook-form";
 import { useWriteStore } from "@/store";
 import { PostWriteFormValues } from "../../_types/PostWriteType";
 import { PostWriteRequest, usePostPosts } from "@/api/fetch/post";
@@ -13,21 +13,45 @@ const usePostWriteSubmit = ({ methods }: UsePostWriteSubmitProps) => {
 
   useEffect(() => {
     methods.setValue("postType", postType ?? "", { shouldValidate: true });
-    methods.setValue("address", fullAddress ?? "", { shouldValidate: true });
+    methods.setValue("address", fullAddress || "", { shouldValidate: true });
     methods.setValue("latitude", lat ?? null, { shouldValidate: true });
     methods.setValue("longitude", lng ?? null, { shouldValidate: true });
     methods.setValue("radius", radius ?? null, { shouldValidate: true });
   }, [postType, fullAddress, lat, lng, radius, methods]);
 
-  const canSubmit = (values: PostWriteFormValues) => {
-    if (!postType) return false;
-    if (!fullAddress) return false;
-    if (lat == null || lng == null || radius == null) return false;
-    if (!values.category) return false;
-    if (!values.title || !values.content) return false;
+  const watchedValues = useWatch({
+    control: methods.control,
+  });
 
-    return true;
-  };
+  const canSubmit = useMemo(() => {
+    const currentPostType = watchedValues.postType || postType;
+    const currentAddress = watchedValues.address || fullAddress;
+    const currentLat = watchedValues.latitude ?? lat;
+    const currentLng = watchedValues.longitude ?? lng;
+    const currentRadius = watchedValues.radius ?? radius;
+
+    const hasLocation =
+      !!currentAddress && currentLat != null && currentLng != null && currentRadius != null;
+    const hasCategory = !!watchedValues.category;
+    const hasTitle = !!watchedValues.title && watchedValues.title.trim() !== "";
+    const hasContent = !!watchedValues.content && watchedValues.content.trim() !== "";
+
+    return !!currentPostType && hasLocation && hasCategory && hasTitle && hasContent;
+  }, [
+    watchedValues.postType,
+    watchedValues.address,
+    watchedValues.latitude,
+    watchedValues.longitude,
+    watchedValues.radius,
+    watchedValues.category,
+    watchedValues.title,
+    watchedValues.content,
+    postType,
+    fullAddress,
+    lat,
+    lng,
+    radius,
+  ]);
 
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [pendingValues, setPendingValues] = useState<PostWriteFormValues | null>(null);

--- a/src/app/(route)/write/post/location/_components/LocationRangeSection/LocationRangeSection.tsx
+++ b/src/app/(route)/write/post/location/_components/LocationRangeSection/LocationRangeSection.tsx
@@ -36,17 +36,13 @@ const LocationRangeSection = ({
 
     try {
       const data = await getKakaoLocalCoord2Address(center.lat, center.lng);
-      if (data.documents && data.documents.length > 0) {
-        const { address: addressDoc } = data.documents[0];
+      const addressDoc = data.documents[0].road_address || data.documents[0].address;
 
-        const newFullAddress =
-          `${addressDoc.region_1depth_name} ${addressDoc.region_2depth_name} ${addressDoc.region_3depth_name}`.trim();
+      const newFullAddress = addressDoc.address_name;
+      const newAddress = addressDoc.region_3depth_name || addressDoc.region_2depth_name;
 
-        const newAddress = addressDoc.region_3depth_name || addressDoc.region_2depth_name;
-
-        setCurrentFullAddress(newFullAddress);
-        setCurrentAddress(newAddress);
-      }
+      setCurrentFullAddress(newFullAddress);
+      setCurrentAddress(newAddress);
     } catch {
       addToast("위치 정보를 불러오는데 실패했어요", "error");
     }

--- a/src/app/(route)/write/post/location/_components/LocationRangeSection/LocationRangeSection.tsx
+++ b/src/app/(route)/write/post/location/_components/LocationRangeSection/LocationRangeSection.tsx
@@ -36,13 +36,15 @@ const LocationRangeSection = ({
 
     try {
       const data = await getKakaoLocalCoord2Address(center.lat, center.lng);
-      const addressDoc = data.documents[0].road_address || data.documents[0].address;
+      if (data.documents && data.documents.length > 0) {
+        const addressDoc = data.documents[0].road_address || data.documents[0].address;
 
-      const newFullAddress = addressDoc.address_name;
-      const newAddress = addressDoc.region_3depth_name || addressDoc.region_2depth_name;
+        const newFullAddress = addressDoc.address_name;
+        const newAddress = addressDoc.region_3depth_name || addressDoc.region_2depth_name;
 
-      setCurrentFullAddress(newFullAddress);
-      setCurrentAddress(newAddress);
+        setCurrentFullAddress(newFullAddress);
+        setCurrentAddress(newAddress);
+      }
     } catch {
       addToast("위치 정보를 불러오는데 실패했어요", "error");
     }

--- a/src/app/(route)/write/post/location/_components/PostWriteFormProvider/PostWriteFormProvider.tsx
+++ b/src/app/(route)/write/post/location/_components/PostWriteFormProvider/PostWriteFormProvider.tsx
@@ -54,7 +54,7 @@ const PostWriteFormProvider = ({ children }: { children: ReactNode }) => {
     prevPathRef.current = pathname;
 
     return () => {
-      if (!window.location.pathname.startsWith("/write/post")) {
+      if (typeof window !== "undefined" && !window.location.pathname.startsWith("/write/post")) {
         resetWriteFlow();
       }
     };

--- a/src/app/(route)/write/post/location/_components/PostWriteFormProvider/PostWriteFormProvider.tsx
+++ b/src/app/(route)/write/post/location/_components/PostWriteFormProvider/PostWriteFormProvider.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ReactNode, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { ReactNode, useEffect, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { PostWriteFormValues } from "../../../_types/PostWriteType";
-import { useWriteFlowStore } from "@/store";
+import { useWriteFlowStore, useWriteStore } from "@/store";
 
 const defaultValues: PostWriteFormValues = {
   postType: "",
@@ -22,20 +23,42 @@ const defaultValues: PostWriteFormValues = {
 };
 
 const PostWriteFormProvider = ({ children }: { children: ReactNode }) => {
+  const { fullAddress, lat: latitude, lng: longitude, radius } = useWriteStore();
+
   const methods = useForm<PostWriteFormValues>({
-    defaultValues,
+    defaultValues: {
+      ...defaultValues,
+      address: fullAddress || "",
+      latitude,
+      longitude,
+      radius,
+    },
     mode: "onChange",
     reValidateMode: "onChange",
     shouldUnregister: false,
   });
 
   const resetWriteFlow = useWriteFlowStore((s) => s.resetWriteFlow);
+  const clearLocation = useWriteStore((s) => s.clearLocation);
+  const pathname = usePathname();
+  const prevPathRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const isNewWritePage = pathname === "/write/post";
+    const isBackFromLocation = prevPathRef.current?.includes("/location");
+
+    if (isNewWritePage && !isBackFromLocation) {
+      clearLocation();
+    }
+
+    prevPathRef.current = pathname;
+
     return () => {
-      resetWriteFlow();
+      if (!window.location.pathname.startsWith("/write/post")) {
+        resetWriteFlow();
+      }
     };
-  }, [resetWriteFlow]);
+  }, [clearLocation, pathname, resetWriteFlow]);
 
   return <FormProvider {...methods}>{children}</FormProvider>;
 };

--- a/src/components/domain/AddToHomeScreenPWA/AddToHomeScreenPWA.tsx
+++ b/src/components/domain/AddToHomeScreenPWA/AddToHomeScreenPWA.tsx
@@ -25,7 +25,7 @@ const AddToHomeScreenPWA = ({ isOpen, onClose }: AddToHomeScreenPWAProps) => {
         <Icon name="Logo" size={60} />
 
         <div className="gap-3 text-center flex-col-center">
-          <h2 className="whitespace-pre-line text-h2-bold text-layout-header-default">
+          <h2 className="text-h3-bold whitespace-pre-line text-layout-header-default">
             홈 화면에 찾아줘를 추가하고{"\n"}더 편리하게 사용하세요
           </h2>
           <p className="whitespace-pre-line text-body2-medium text-layout-body-default">

--- a/src/components/domain/BetaTest/BetaTestMainBanner/BetaTestMainBanner.tsx
+++ b/src/components/domain/BetaTest/BetaTestMainBanner/BetaTestMainBanner.tsx
@@ -30,8 +30,10 @@ const BetaTestMainBanner = () => {
           height={47}
           priority
           draggable={false}
+          quality={100}
+          className="h-[47px] w-[68px] shrink-0"
         />
-        <div className="flex flex-col gap-2 text-center text-[12px] leading-[8.1px] tracking-[-0.05em] text-white">
+        <div className="flex flex-col gap-2 text-nowrap text-center text-[12px] leading-[8.1px] tracking-[-0.05em] text-white">
           <span>설문 참여하고</span>
           <span className="font-bold">커피 쿠폰 받아가세요!</span>
         </div>

--- a/src/components/domain/FilterSectionBottomSheet/FilterBottomSheet/FilterBottomSheet.tsx
+++ b/src/components/domain/FilterSectionBottomSheet/FilterBottomSheet/FilterBottomSheet.tsx
@@ -96,7 +96,11 @@ const FilterBottomSheet = ({
     !isLoading && filters.region.trim().length >= 2 && results.length === 0;
 
   return (
-    <PopupLayout isOpen={isOpen} onClose={() => setIsOpen(false)} className="min-h-[530px] py-10">
+    <PopupLayout
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      className="flex h-[574px] flex-col py-10"
+    >
       <div className="w-full gap-6 flex-col-center">
         <h2 className="text-h2-medium text-layout-header-default">필터</h2>
 
@@ -259,9 +263,7 @@ const FilterBottomSheet = ({
         )}
       </div>
 
-      {selectedTab !== "region" && <div className="h-[230px] w-full" />}
-
-      <Button role="button" ariaLabel="필터 적용" className="w-full" onClick={handleApply}>
+      <Button role="button" ariaLabel="필터 적용" className="mt-auto w-full" onClick={handleApply}>
         적용하기
       </Button>
     </PopupLayout>


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 게시글 목록
  - 필터 높이 고정 값 추가

- 게시글 상세
  - 즐겨찾기 삭제 시 게시글 목록 invalidate 추가
  - 비슷한 분실물 제목을 각 타입에 맞게 반환
  - 비슷한 분실물 아이템 디자인 변경 사항 반영

- 게시글 수정
  - 배포 기준 수정 페이지 값이 채워지지 않는 문제 수정 (배포 후 테스트 필요)

- 메인
  - 베타 테스트 이미지 레이아웃 시프트 현상 개선

- PWA 컴포넌트
  - 텍스트 디자인 토큰 수정

## 참고 사항

- <!-- 리뷰어가 알아야 할 맥락이나 주의할 점이 있다면 작성해주세요. -->

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
