### PR TITLE
QA 해결

### DIFF
--- a/src/api/fetch/report/api/useReport.ts
+++ b/src/api/fetch/report/api/useReport.ts
@@ -8,11 +8,11 @@ import { AxiosError } from "axios";
 interface UseReportParams {
   reset: () => void;
   setReportType: (reportType: ReportReason | null) => void;
-  invalidateKey?: QueryKey;
+  invalidateKeys?: QueryKey[];
   onClose: () => void;
 }
 
-const useReport = ({ reset, setReportType, invalidateKey, onClose }: UseReportParams) => {
+const useReport = ({ reset, setReportType, invalidateKeys, onClose }: UseReportParams) => {
   const toast = useToast();
   const queryClient = useQueryClient();
 
@@ -22,7 +22,9 @@ const useReport = ({ reset, setReportType, invalidateKey, onClose }: UseReportPa
       setReportType(null);
       toast.addToast("신고가 접수되었어요", "success");
       queryClient.invalidateQueries({ queryKey: ["reports/me"] });
-      invalidateKey && queryClient.invalidateQueries({ queryKey: invalidateKey });
+      invalidateKeys?.forEach((key) => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
       onClose();
     },
     onError: (error) => {

--- a/src/app/(home)/_components/DefaultSheetContent/_internal/LostFindActions/LostFindActions.tsx
+++ b/src/app/(home)/_components/DefaultSheetContent/_internal/LostFindActions/LostFindActions.tsx
@@ -15,7 +15,10 @@ const LostFindActions = () => {
               href={`/list?type=${type}`}
               key={type}
               aria-label={`${title} 목록 페이지로 이동`}
-              className={cn("relative h-[106px] w-full min-w-0 flex-1 rounded-2xl", bgColor)}
+              className={cn(
+                "relative h-[106px] w-full min-w-0 flex-1 overflow-hidden rounded-2xl",
+                bgColor
+              )}
               onDragStart={(e) => e.preventDefault()}
             >
               <Image draggable={false} src={positionImage} alt="" width={50} height={70} priority />

--- a/src/app/(home)/_components/HomeFilterSection/_internal/CategoryFilter/CategoryFilter.tsx
+++ b/src/app/(home)/_components/HomeFilterSection/_internal/CategoryFilter/CategoryFilter.tsx
@@ -3,7 +3,8 @@
 import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/components/common";
-import { CATEGORY_OPTIONS } from "@/constants";
+import { MAP_CATEGORY_FILTER_OPTIONS } from "@/constants";
+import { CATEGORY_FILTER_DROPDOWN_MIN_WIDTH_PX } from "../../../../_constants/FILTER";
 import { cn } from "@/utils";
 import { usePopoverOutsideClose, usePopoverPosition } from "@/hooks";
 import HomeFilter from "../HomeFilter/HomeFilter";
@@ -28,11 +29,16 @@ const CategoryFilter = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   usePopoverOutsideClose(isOpen, triggerRef, dropdownRef, () => setIsOpen(false));
-  usePopoverPosition(isOpen, triggerRef, dropdownRef);
+  usePopoverPosition(
+    isOpen,
+    triggerRef,
+    dropdownRef,
+    undefined,
+    CATEGORY_FILTER_DROPDOWN_MIN_WIDTH_PX
+  );
 
   const handleOptionClick = (value: string) => {
-    const nextValue = selectedValue === value ? undefined : value;
-    onSelect(nextValue);
+    onSelect(value === "" ? undefined : value);
     setIsOpen(false);
   };
 
@@ -51,13 +57,17 @@ const CategoryFilter = ({
 
       {isOpen &&
         createPortal(
-          <div ref={dropdownRef} className="fixed z-50 flex flex-col">
-            {CATEGORY_OPTIONS.map((option) => (
+          <div
+            ref={dropdownRef}
+            className="fixed z-50 flex max-h-[200px] min-h-0 flex-col overflow-y-auto overscroll-y-contain rounded-[20px] no-scrollbar"
+          >
+            {MAP_CATEGORY_FILTER_OPTIONS.map((option) => (
               <button
-                key={option.value}
+                key={option.value === "" ? "all" : option.value}
+                type="button"
                 onClick={() => handleOptionClick(option.value)}
                 className={cn(
-                  "glass-card w-full text-nowrap border border-white bg-flatGray-25/70 px-7 py-4 text-h3-medium text-neutral-normal-default transition-colors flex-center",
+                  "glass-card h-[58px] w-full shrink-0 text-nowrap border border-white bg-flatGray-25/70 px-7 text-h3-medium text-neutral-normal-default transition-colors flex-center",
                   "first:rounded-t-[20px] last:rounded-b-[20px]"
                 )}
               >

--- a/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
+++ b/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 const MainSearchEmpty = () => {
   return (
-    <div className="w-full gap-5 pt-20 flex-col-center">
+    <div className="w-full gap-5 pt-5 flex-col-center">
       <div className="h-[54px] w-[54px] rounded-full border-[2.8px] border-white/30 backdrop-blur-[11.19px] bg-fill-brand-subtle-pressed flex-center">
         <Icon name="MainSearchWarning" size={48} className="mt-1" />
       </div>

--- a/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
+++ b/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon } from "@/components/common";
+import Link from "next/link";
 
 const MainSearchEmpty = () => {
   return (
@@ -10,8 +11,8 @@ const MainSearchEmpty = () => {
       <span className="whitespace-pre-line text-center text-body2-regular text-layout-body-default">
         {`찾으시는 물건이 아직 등록되지 않았네요.\n직접 글을 올려 더 많은 사람에게 알려보세요.`}
       </span>
-      <Button variant="outlined" size="big">
-        게시글 작성하러 가기
+      <Button as={Link} href="/list" variant="outlined" size="big">
+        게시글 살펴보러 가기
       </Button>
     </div>
   );

--- a/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
+++ b/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
@@ -78,6 +78,10 @@ const HeaderSearchForm = ({
     if (focused) {
       inputRef.current?.blur();
       setFocused(false);
+      if (!searchValue?.trim()) {
+        setValue("search", "");
+        setSearchKeyword("");
+      }
       return;
     }
     router.back();
@@ -102,7 +106,13 @@ const HeaderSearchForm = ({
           setSearchKeyword(e.target.value);
         }}
         type="text"
-        onFocus={() => setFocused(true)}
+        onFocus={() => {
+          setFocused(true);
+          if (!searchValue?.trim()) {
+            setValue("search", locationPlaceholder);
+            setSearchKeyword(locationPlaceholder);
+          }
+        }}
         className={cn(
           "w-full pl-8 text-h3-semibold text-flatGray-700 placeholder:text-flatGray-700"
         )}

--- a/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
+++ b/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
@@ -108,9 +108,9 @@ const HeaderSearchForm = ({
         type="text"
         onFocus={() => {
           setFocused(true);
-          if (!searchValue?.trim()) {
-            setValue("search", locationPlaceholder);
-            setSearchKeyword(locationPlaceholder);
+          if (!searchValue?.trim() && geoGranted && isResolvedGpsAddress) {
+            setValue("search", userGpsAddress);
+            setSearchKeyword(userGpsAddress);
           }
         }}
         className={cn(

--- a/src/app/(home)/_components/MyLocationButton/MyLocationButton.tsx
+++ b/src/app/(home)/_components/MyLocationButton/MyLocationButton.tsx
@@ -2,18 +2,27 @@
 
 import { Icon } from "@/components/common";
 import useMyLocationButton from "../../_hooks/useMyLocationButton";
+import { LocationPermissionBottomSheet } from "../PermissionBottomSheet/PermissionBottomSheet";
 
 const MyLocationButton = () => {
-  const { handleMyLocationClick } = useMyLocationButton();
+  const { handleMyLocationClick, isLocationPermissionSheetOpen, closeLocationPermissionSheet } =
+    useMyLocationButton();
 
   return (
-    <button
-      aria-label="내 위치로 이동"
-      onClick={handleMyLocationClick}
-      className="absolute bottom-3 right-3 flex h-[38px] w-[38px] rounded-full bg-white shadow-lg flex-center"
-    >
-      <Icon name="MapMyLocation" size={20} />
-    </button>
+    <>
+      <button
+        aria-label="내 위치로 이동"
+        onClick={handleMyLocationClick}
+        className="absolute bottom-3 right-3 flex h-[38px] w-[38px] rounded-full bg-white shadow-lg flex-center"
+      >
+        <Icon name="MapMyLocation" size={20} />
+      </button>
+
+      <LocationPermissionBottomSheet
+        isOpen={isLocationPermissionSheetOpen}
+        onClose={closeLocationPermissionSheet}
+      />
+    </>
   );
 };
 

--- a/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
+++ b/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
@@ -27,13 +27,15 @@ const DetailPermissionSheet = ({ isOpen, onClose, state }: DetailPermissionSheet
       }
       navigator.geolocation.getCurrentPosition(
         ({ coords }) => {
-          useMainKakaoMapStore.getState().setUserGpsFromDevice({
-            lat: coords.latitude,
-            lng: coords.longitude,
-          });
+          const next = { lat: coords.latitude, lng: coords.longitude };
+          useMainKakaoMapStore.getState().triggerLevelReset();
+          useMainKakaoMapStore.getState().setUserGpsFromDevice(next);
+          useMainKakaoMapStore.getState().setLatLng(next);
           onClose();
         },
         (error) => {
+          useMainKakaoMapStore.getState().triggerLevelReset();
+          useMainKakaoMapStore.getState().clearLatLng();
           if (error.code === error.PERMISSION_DENIED) {
             addToast("위치 권한이 거부되었습니다. 설정에서 허용해주세요.", "warning");
           }
@@ -167,5 +169,13 @@ const PermissionSheet = ({ isOpen, onClose }: PermissionSheetProps) => {
     </PopupLayout>
   );
 };
+
+export const LocationPermissionBottomSheet = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => <DetailPermissionSheet isOpen={isOpen} onClose={onClose} state="Location" />;
 
 export default PermissionSheet;

--- a/src/app/(home)/_constants/FILTER.ts
+++ b/src/app/(home)/_constants/FILTER.ts
@@ -28,3 +28,5 @@ export const POST_FILTER_ITEMS = FILTER_ITEMS.filter(
 export const CATEGORY_FILTER_ITEM = FILTER_ITEMS.find(
   (item): item is { label: string; value: "category" } => item.value === "category"
 ) ?? { label: "카테고리", value: "category" as FilterItemValue };
+
+export const CATEGORY_FILTER_DROPDOWN_MIN_WIDTH_PX = 107;

--- a/src/app/(home)/_hooks/useBottomSheetHeight.ts
+++ b/src/app/(home)/_hooks/useBottomSheetHeight.ts
@@ -30,6 +30,7 @@ const getTargetHeight = ({
   const points = getSnapHeights(max, { searchValue, contentHeights, markerId });
 
   if (searchValue) return max;
+  if (contentHeights && !markerId) return points[1];
   return points[2];
 };
 

--- a/src/app/(home)/_hooks/useMyLocationButton.ts
+++ b/src/app/(home)/_hooks/useMyLocationButton.ts
@@ -1,9 +1,10 @@
 import { useMainKakaoMapStore } from "@/store";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const useMyLocationButton = () => {
   const { setLatLng, setUserGpsFromDevice, clearLatLng, triggerLevelReset } =
     useMainKakaoMapStore();
+  const [isLocationPermissionSheetOpen, setIsLocationPermissionSheetOpen] = useState(false);
 
   useEffect(() => {
     const checkGeolocationPermission = async () => {
@@ -26,7 +27,7 @@ const useMyLocationButton = () => {
     void checkGeolocationPermission();
   }, [clearLatLng]);
 
-  const handleMyLocationClick = () => {
+  const requestDeviceLocation = useCallback(() => {
     if (!navigator.geolocation) {
       clearLatLng();
       return;
@@ -44,10 +45,40 @@ const useMyLocationButton = () => {
         clearLatLng();
       }
     );
+  }, [clearLatLng, setLatLng, setUserGpsFromDevice, triggerLevelReset]);
+
+  const handleMyLocationClick = async () => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      clearLatLng();
+      return;
+    }
+
+    if (navigator.permissions) {
+      try {
+        const result = await navigator.permissions.query({ name: "geolocation" });
+        if (result.state === "granted") {
+          requestDeviceLocation();
+          return;
+        }
+        setIsLocationPermissionSheetOpen(true);
+        return;
+      } catch {
+        requestDeviceLocation();
+        return;
+      }
+    }
+
+    requestDeviceLocation();
   };
+
+  const closeLocationPermissionSheet = useCallback(() => {
+    setIsLocationPermissionSheetOpen(false);
+  }, []);
 
   return {
     handleMyLocationClick,
+    isLocationPermissionSheetOpen,
+    closeLocationPermissionSheet,
   };
 };
 

--- a/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
+++ b/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
@@ -13,12 +13,13 @@ import { EmptyState } from "@/components/state";
 import { useInfiniteScroll } from "@/hooks";
 import { cn, formatDate } from "@/utils";
 import { useRouter } from "next/navigation";
+import type { Dispatch, SetStateAction } from "react";
 
 interface AlertItemProps {
   item: NotificationListItem;
   isDeleteMode: boolean;
   selectedNotifications: number[];
-  setSelectedNotifications: (selectedNotifications: number[]) => void;
+  setSelectedNotifications: Dispatch<SetStateAction<number[]>>;
 }
 
 const AlertItem = ({
@@ -37,11 +38,9 @@ const AlertItem = ({
   const isSelected = selectedNotifications.includes(notificationId);
 
   const handleSelectNotification = (id: number) => {
-    if (selectedNotifications.includes(id)) {
-      setSelectedNotifications(selectedNotifications.filter((n) => n !== id));
-    } else {
-      setSelectedNotifications([...selectedNotifications, id]);
-    }
+    setSelectedNotifications((prev) =>
+      prev.includes(id) ? prev.filter((n) => n !== id) : [...prev, id]
+    );
   };
 
   const handleRowClick = () => {
@@ -114,7 +113,7 @@ const AlertItem = ({
 interface AlertListProps {
   isDeleteMode: boolean;
   selectedNotifications: number[];
-  setSelectedNotifications: (selectedNotifications: number[]) => void;
+  setSelectedNotifications: Dispatch<SetStateAction<number[]>>;
 }
 
 const AlertList = ({

--- a/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
+++ b/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
@@ -36,43 +36,56 @@ const AlertItem = ({
   const IconSize = referenceType === "NOTICE" ? 20 : 15;
   const isSelected = selectedNotifications.includes(notificationId);
 
-  const handleAlertRoute = () => {
-    if (isDeleteMode) return;
+  const handleSelectNotification = (id: number) => {
+    if (selectedNotifications.includes(id)) {
+      setSelectedNotifications(selectedNotifications.filter((n) => n !== id));
+    } else {
+      setSelectedNotifications([...selectedNotifications, id]);
+    }
+  };
 
+  const handleRowClick = () => {
+    if (isDeleteMode) {
+      handleSelectNotification(notificationId);
+      return;
+    }
     readNotification({ ids: [notificationId] });
     router.push(alertRouteUrl(referenceType, referenceId));
   };
 
-  const handleSelectNotification = (notificationId: number) => {
-    if (selectedNotifications.includes(notificationId)) {
-      setSelectedNotifications(selectedNotifications.filter((id) => id !== notificationId));
-    } else {
-      setSelectedNotifications([...selectedNotifications, notificationId]);
-    }
-  };
-
   return (
     <button
-      onClick={handleAlertRoute}
-      aria-label="알림 확인, 외부 페이지 이동"
-      key={notificationId}
+      type="button"
+      onClick={handleRowClick}
+      aria-label={
+        isDeleteMode
+          ? isSelected
+            ? "선택된 알림, 탭하면 선택 해제"
+            : "알림 선택"
+          : "알림 확인, 외부 페이지 이동"
+      }
       className={cn(
         "flex min-h-[86px] w-full items-start gap-3 border-b border-divider-default p-5 text-left transition-colors",
-        isDeleteMode ? "cursor-default" : "cursor-pointer",
+        "cursor-pointer",
         isRead
           ? ALERT_ROW_BG.read[isDeleteMode ? "delete" : "default"]
           : ALERT_ROW_BG.unread[isDeleteMode ? "delete" : "default"]
       )}
     >
       {isDeleteMode && (
-        <CheckBox
-          id={String(notificationId)}
-          checked={isSelected}
-          label=""
-          boxSize="size-6"
-          onChange={() => handleSelectNotification(notificationId)}
+        <span
+          className="flex shrink-0"
           onClick={(e) => e.stopPropagation()}
-        />
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <CheckBox
+            id={String(notificationId)}
+            checked={isSelected}
+            label=""
+            boxSize="size-6"
+            onChange={() => handleSelectNotification(notificationId)}
+          />
+        </span>
       )}
       <div className={cn("h-[30px] w-[30px] flex-shrink-0 rounded-full flex-center", bg)}>
         <Icon name={icon as IconName} size={IconSize} />

--- a/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
+++ b/src/app/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
@@ -33,7 +33,7 @@ const AlertItem = ({
   const { mutate: readNotification } = useNotificationRead();
   const { icon, bg } = getAlertIconBackgroundColor(type, referenceType);
   const titleSegments = getAlertTitleSegments(type, title);
-  const IconSize = referenceType === "NOTICE" ? 20 : 15;
+  const IconSize = referenceType === "NOTICE" && type !== "COMMENT" ? 20 : 15;
   const isSelected = selectedNotifications.includes(notificationId);
 
   const handleSelectNotification = (id: number) => {

--- a/src/app/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton.tsx
+++ b/src/app/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton.tsx
@@ -77,6 +77,7 @@ const ChatRoomHeaderInfoButton = ({ roomId }: { roomId: number }) => {
         onClose={() => setReportOpen(false)}
         targetId={roomId}
         targetType="CHAT"
+        invalidateKeys={[["chatRoom", roomId], ["posts"], ["user-block-list"]]}
       />
 
       <ChatLeaveModal

--- a/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
+++ b/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
@@ -102,6 +102,7 @@ const InputChat = ({
                 )}
                 placeholder="메시지 보내기"
                 disabled={disabled}
+                maxLength={255}
               />
 
               {/* 전송 버튼 */}

--- a/src/app/(route)/notice/_components/NoticeList/NoticeList.tsx
+++ b/src/app/(route)/notice/_components/NoticeList/NoticeList.tsx
@@ -1,11 +1,13 @@
 import { Badge, Icon, ListItemImage } from "@/components/common";
 import Link from "next/link";
 import { NoticeItem } from "@/api/fetch/notice";
-import { formatDate } from "@/utils";
+import { formatDate, highlightText } from "@/utils";
 import { EmptyState } from "@/components/state";
+import { useSearchParams } from "next/navigation";
 
 const NoticeListItem = ({ notice }: { notice: NoticeItem }) => {
   const { noticeId, title, createdAt, likeCount, viewCount, thumbnailUrl, isNew, isHot } = notice;
+  const keyword = useSearchParams().get("keyword") || "";
 
   return (
     <li>
@@ -20,7 +22,9 @@ const NoticeListItem = ({ notice }: { notice: NoticeItem }) => {
                 {isNew && <Badge variant="new" />}
                 {isHot && <Badge variant="hot" />}
               </div>
-              <p className="truncate text-body1-semibold text-layout-header-default">{title}</p>
+              <p className="truncate text-body1-semibold text-layout-header-default">
+                {highlightText(title, keyword)}
+              </p>
             </div>
             <time className="text-body2-regular text-layout-body-default">
               {formatDate(createdAt)}

--- a/src/app/(route)/notice/_components/NoticeList/NoticeList.tsx
+++ b/src/app/(route)/notice/_components/NoticeList/NoticeList.tsx
@@ -7,7 +7,7 @@ import { useSearchParams } from "next/navigation";
 
 const NoticeListItem = ({ notice }: { notice: NoticeItem }) => {
   const { noticeId, title, createdAt, likeCount, viewCount, thumbnailUrl, isNew, isHot } = notice;
-  const keyword = useSearchParams().get("keyword") || "";
+  const keyword = useSearchParams()?.get("keyword") || "";
 
   return (
     <li>

--- a/src/components/domain/PopupLayout/PopupLayout.test.tsx
+++ b/src/components/domain/PopupLayout/PopupLayout.test.tsx
@@ -42,13 +42,14 @@ describe("<PopupLayout />", () => {
 
   it("백드롭에서 mousedown 시 onClose가 호출됩니다.", () => {
     const onClose = jest.fn();
-    const { container } = render(
+    render(
       <PopupLayout isOpen onClose={onClose}>
         <p>팝업 내용</p>
       </PopupLayout>
     );
 
-    const backdrop = container.firstChild as HTMLElement;
+    const content = screen.getByText("팝업 내용").parentElement as HTMLElement;
+    const backdrop = content.parentElement as HTMLElement;
     expect(backdrop).toBeInTheDocument();
 
     fireEvent.mouseDown(backdrop);
@@ -57,30 +58,29 @@ describe("<PopupLayout />", () => {
 
   it("컨텐츠 내부 클릭은 이벤트 전파를 막아 onClose가 호출되지 않습니다.", () => {
     const onClose = jest.fn();
-    const { container } = render(
+    render(
       <PopupLayout isOpen onClose={onClose}>
         <button>내부 버튼</button>
       </PopupLayout>
     );
 
-    const backdrop = container.firstChild as HTMLElement;
-    const content = backdrop.firstChild as HTMLElement;
+    const content = screen.getByText("내부 버튼").parentElement as HTMLElement;
 
-    fireEvent.click(content);
+    fireEvent.mouseDown(content);
     expect(onClose).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByText("내부 버튼"));
+    fireEvent.mouseDown(screen.getByText("내부 버튼"));
     expect(onClose).not.toHaveBeenCalled();
   });
 
   it("추가 className이 병합되어 적용됩니다.", () => {
-    const { container } = render(
+    render(
       <PopupLayout isOpen className="custom-class">
         <p>내용</p>
       </PopupLayout>
     );
-    const backdrop = container.firstChild as HTMLElement;
-    const content = backdrop.firstChild as HTMLElement;
+
+    const content = screen.getByText("내용").parentElement as HTMLElement;
     expect(content).toHaveClass("custom-class");
   });
 

--- a/src/components/domain/PopupLayout/PopupLayout.tsx
+++ b/src/components/domain/PopupLayout/PopupLayout.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/utils";
 import { useModalBackdrop, useModalLockAndEsc } from "@/hooks";
+import { createPortal } from "react-dom";
 
 /**
  * @author jikwon
@@ -32,8 +33,9 @@ const PopupLayout = ({ isOpen, onClose, children, className }: PopupLayoutProps)
   const onBackdropMouseDown = useModalBackdrop({ onClose });
 
   if (!isOpen) return null;
+  if (typeof document === "undefined") return null;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[9999] flex items-end justify-center bg-black/30"
       onMouseDown={onBackdropMouseDown}
@@ -48,7 +50,8 @@ const PopupLayout = ({ isOpen, onClose, children, className }: PopupLayoutProps)
       >
         {children}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/domain/ReportModal/ReportModal.tsx
+++ b/src/components/domain/ReportModal/ReportModal.tsx
@@ -18,7 +18,7 @@ interface ReportModalProps {
   onClose: () => void;
   targetType: ReportTargetType;
   targetId: number;
-  invalidateKey?: QueryKey;
+  invalidateKeys?: QueryKey[];
 }
 
 /**
@@ -33,7 +33,7 @@ interface ReportModalProps {
  * @param onClose - 모달을 닫을 때 호출되는 콜백 함수
  * @param targetType - 신고 대상의 타입 ("CHAT" | "POST" | "COMMENT" | "USER")
  * @param targetId - 신고 대상의 ID
- * @param invalidateKey - 신고 성공 후 무효화할 Tanstack Query 쿼리 키 (선택)
+ * @param invalidateKeys - 신고 성공 후 무효화할 Tanstack Query 키 목록 (선택)
  *
  * @example
  * ```tsx
@@ -44,7 +44,7 @@ interface ReportModalProps {
  *   onClose={() => setReportOpen(false)}
  *   targetType="CHAT"
  *   targetId={roomId}
- *   invalidateKey={["chatRoom", roomId]}
+ *   invalidateKeys={[ ["chatRoom", roomId], ["posts"], ["user-block-list"] ]}
  * />
  * ```
  */
@@ -54,7 +54,7 @@ const ReportModal = ({
   onClose,
   targetType,
   targetId,
-  invalidateKey,
+  invalidateKeys,
 }: ReportModalProps) => {
   const [openReportReasonModal, setOpenReportReasonModal] = useState(false);
   const [reportType, setReportType] = useState<ReportReason | null>(null);
@@ -65,7 +65,7 @@ const ReportModal = ({
   const { mutate: report, isPending } = useReport({
     reset: () => methods.reset(),
     setReportType: (reportType: ReportReason | null) => setReportType(reportType),
-    invalidateKey: invalidateKey,
+    invalidateKeys,
     onClose: onClose,
   });
 

--- a/src/components/layout/DetailHeader/DetailHeader.tsx
+++ b/src/components/layout/DetailHeader/DetailHeader.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/components/common";
+import { cn } from "@/utils";
 
 interface DetailHeaderProps {
   title?: ReactNode;
@@ -43,6 +44,8 @@ interface DetailHeaderProps {
  * ```
  */
 
+const HEADER_HEIGHT = "h-14";
+
 const DetailHeader = ({ title = "", children, onBack }: DetailHeaderProps) => {
   const router = useRouter();
 
@@ -65,24 +68,32 @@ const DetailHeader = ({ title = "", children, onBack }: DetailHeaderProps) => {
   };
 
   return (
-    <header className="sticky top-0 z-30 flex h-14 w-full items-center justify-between bg-white px-5">
-      <div className="flex items-center gap-2">
-        <button
-          className="h-[30px] w-[30px]"
-          type="button"
-          onClick={handleBack}
-          aria-label="뒤로가기"
-        >
-          <Icon name="ArrowLeftSmall" size={30} className="text-neutral-strong-default" />
-        </button>
-        {title && <h2 className="text-xl font-semibold text-layout-header-default">{title}</h2>}
-      </div>
-      {children && (
-        <div className="flex gap-[23.5px]" aria-label="헤더 액션">
-          {children}
+    <>
+      <header
+        className={cn(
+          "fixed top-0 z-30 mx-auto flex h-14 w-full max-w-[764px] items-center justify-between bg-white px-5",
+          HEADER_HEIGHT
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <button
+            className="h-[30px] w-[30px]"
+            type="button"
+            onClick={handleBack}
+            aria-label="뒤로가기"
+          >
+            <Icon name="ArrowLeftSmall" size={30} className="text-neutral-strong-default" />
+          </button>
+          {title && <h2 className="text-xl font-semibold text-layout-header-default">{title}</h2>}
         </div>
-      )}
-    </header>
+        {children && (
+          <div className="flex gap-[23.5px]" aria-label="헤더 액션">
+            {children}
+          </div>
+        )}
+      </header>
+      <div className={HEADER_HEIGHT} aria-hidden />
+    </>
   );
 };
 

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -3,18 +3,23 @@
 import { FooterItem } from "./_internal";
 import useFooterNav from "./_hooks/useFooterNav";
 
+const FOOTER_HEIGHT = "h-[86.67px]";
+
 const Footer = ({ hasToken = false }: { hasToken?: boolean }) => {
   const { isHidden, items } = useFooterNav(hasToken);
   if (isHidden) return null;
 
   return (
-    <footer className="sticky bottom-0 left-1/2 z-50 mx-auto w-full max-w-[768px] overflow-visible border-t-[1.2px] border-divider-default bg-white px-5 pb-[27px] pt-[14px]">
-      <nav className="flex justify-between text-caption2-medium text-labelsVibrant-secondary">
-        {items.map((item) => (
-          <FooterItem key={item.key} item={item} />
-        ))}
-      </nav>
-    </footer>
+    <>
+      <footer className="fixed bottom-0 mx-auto w-full max-w-[764px] overflow-visible border-t-[1.2px] border-divider-default bg-white px-5 pb-[27px] pt-[14px]">
+        <nav className="flex justify-between text-caption2-medium text-labelsVibrant-secondary">
+          {items.map((item) => (
+            <FooterItem key={item.key} item={item} />
+          ))}
+        </nav>
+      </footer>
+      <div className={FOOTER_HEIGHT} aria-hidden />
+    </>
   );
 };
 

--- a/src/constants/CATEGORY_OPTIONS.ts
+++ b/src/constants/CATEGORY_OPTIONS.ts
@@ -8,6 +8,12 @@ export const CATEGORY_OPTIONS = [
   { value: "ETC", label: "기타" },
 ] as const;
 
+/** 메인 지도 카테고리 필터 드롭다운(맨 위 `전체` = 쿼리 없음) */
+export const MAP_CATEGORY_FILTER_OPTIONS: readonly { value: string; label: string }[] = [
+  { value: "", label: "전체" },
+  ...CATEGORY_OPTIONS,
+];
+
 export const NOTICE_WRITE_CATEGORY_OPTIONS = [
   { value: "IMPORTANT", label: "중요" },
   { value: "UPDATE", label: "업데이트" },

--- a/src/hooks/usePopoverPosition/usePopoverPosition.ts
+++ b/src/hooks/usePopoverPosition/usePopoverPosition.ts
@@ -5,7 +5,7 @@ const DEFAULT_POPOVER_OFFSET = 8;
 /**
  * @author hyungjun
  *
- * anchor 위치를 기준으로 popover 레이어의 좌표를 동기화하는 훅입니다.
+ * anchor 위치·너비를 기준으로 popover 레이어의 좌표·폭을 동기화하는 훅입니다.
  *
  * 열림 상태에서 최초 1회 좌표를 계산하고, 스크롤/리사이즈 시 좌표를 갱신합니다.
  *
@@ -13,13 +13,15 @@ const DEFAULT_POPOVER_OFFSET = 8;
  * @param anchorRef - 기준(트리거) 요소 ref
  * @param popoverRef - popover 레이어 요소 ref
  * @param offset - anchor 하단에서 popover까지의 간격(px), 기본값 8
+ * @param minWidthPx - popover 최소 너비(px). 앵커가 더 좁을 때 옵션 텍스트가 잘리지 않게 할 때 사용
  */
 
 const usePopoverPosition = (
   isOpen: boolean,
   anchorRef: React.RefObject<HTMLDivElement | null>,
   popoverRef: React.RefObject<HTMLDivElement | null>,
-  offset: number = DEFAULT_POPOVER_OFFSET
+  offset: number = DEFAULT_POPOVER_OFFSET,
+  minWidthPx?: number
 ) => {
   useEffect(() => {
     if (!isOpen) return;
@@ -27,9 +29,11 @@ const usePopoverPosition = (
     const updatePosition = () => {
       if (!anchorRef.current || !popoverRef.current) return;
 
-      const { left, top, height } = anchorRef.current.getBoundingClientRect();
+      const { left, top, height, width } = anchorRef.current.getBoundingClientRect();
+      const popoverWidth = minWidthPx != null ? Math.max(width, minWidthPx) : width;
       popoverRef.current.style.left = `${left}px`;
       popoverRef.current.style.top = `${top + height + offset}px`;
+      popoverRef.current.style.width = `${popoverWidth}px`;
     };
 
     updatePosition();
@@ -40,7 +44,7 @@ const usePopoverPosition = (
       window.removeEventListener("scroll", updatePosition, true);
       window.removeEventListener("resize", updatePosition);
     };
-  }, [isOpen, anchorRef, popoverRef, offset]);
+  }, [isOpen, anchorRef, popoverRef, offset, minWidthPx]);
 };
 
 export default usePopoverPosition;

--- a/src/providers/ToastProviders.tsx
+++ b/src/providers/ToastProviders.tsx
@@ -27,7 +27,7 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
       {children}
       {mounted &&
         createPortal(
-          <div className="pointer-events-none fixed inset-x-0 top-6 z-[9999] flex w-full flex-col items-stretch gap-2 px-4">
+          <div className="pointer-events-none fixed inset-x-0 top-6 z-[10000] flex w-full flex-col items-stretch gap-2 px-4">
             <AnimatePresence>
               {toasts.map((toast) => (
                 <motion.div

--- a/src/store/useMainKakaoMapStore/getAddressFromLatLng.ts
+++ b/src/store/useMainKakaoMapStore/getAddressFromLatLng.ts
@@ -7,8 +7,9 @@ import { extractDongAddress } from "@/utils";
  * @author hyungjun
  * @description
  * - 좌표(lat, lng)를 카카오 API로 변환한 뒤,
- * - `address_name`에서 화면에 표시하기 적합하도록 `00동` 단위 문자열을 우선 추출하고,
- * - 실패 시 `road_address`/`address` 원문을 fallback으로 사용합니다.
+ * - 기본(`variant: "short"`)은 `address_name`에서 `00동` 단위 문자열을 우선 추출하고,
+ *   실패 시 `road_address`/`address` 원문을 fallback으로 사용합니다.
+ * - `variant: "full"`이면 도로명·지번 주소 원문을 그대로 반환합니다(플레이스홀더 등).
  *
  * @param lat 위도(y)
  * @param lng 경도(x)
@@ -22,16 +23,26 @@ import { extractDongAddress } from "@/utils";
  * ```
  */
 
+export type GetAddressFromLatLngOptions = {
+  /** `"short"`(기본): 동 단위 우선. `"full"`: API `road_address`/`address` 전체 문자열 */
+  variant?: "short" | "full";
+};
+
 export const getAddressFromLatLng = async (
   lat: number,
   lng: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options?: GetAddressFromLatLngOptions
 ): Promise<string> => {
   const data = await getKakaoLocalCoord2Address(lat, lng, signal);
   const firstDocument = data.documents?.[0];
   const roadAddress = firstDocument?.road_address?.address_name ?? "";
   const jibunAddress = firstDocument?.address?.address_name ?? "";
-  const dongAddress = extractDongAddress(jibunAddress) || extractDongAddress(roadAddress);
 
+  if (options?.variant === "full") {
+    return roadAddress || jibunAddress || "";
+  }
+
+  const dongAddress = extractDongAddress(jibunAddress) || extractDongAddress(roadAddress);
   return dongAddress || roadAddress || jibunAddress || "";
 };

--- a/src/store/useMainKakaoMapStore/useMainKakaoMapStore.ts
+++ b/src/store/useMainKakaoMapStore/useMainKakaoMapStore.ts
@@ -78,7 +78,9 @@ export const useMainKakaoMapStore = create<MainKakaoMapStore>()(
         const controller = userGpsAbortController;
 
         try {
-          const userGpsAddress = await getAddressFromLatLng(lat, lng, controller.signal);
+          const userGpsAddress = await getAddressFromLatLng(lat, lng, controller.signal, {
+            variant: "full",
+          });
           if (controller.signal.aborted) return;
           set({ userGpsAddress });
         } catch {


### PR DESCRIPTION
# Pull Request

## 작업 내용
남은 QA들을 한 브랜치에 정리하였습니다.

- 메인 LostFindActions 모서리 overflow hidden 추가
- 공지사항 검색 하이라이팅 구현
- 위치 정보 허용 바텀 시트 구현
- 메인 SearchInput 전체 주소 표시
- 메인 검색 모드일 때 현재 주소가 value로 들어가도록
- 알림 삭제 모드 아이템 영역 클릭해서 선택 가능하도록
- 바텀 시트 기본 높이 첫 번째 영역으로 수정
- 메인 empty 버튼 텍스트, 라우팅 수정
- DetailHeader, Footer fixed로 변경
- 채팅 input 255자 제한
- 채팅 차단/신고 후 게시글 목록, 차단 내역 invalidate (API 변경 전 선 반영)
- 토스트 z-index 증가
- 알림 아이콘 크기 조건 수정
- 메인 카테고리 필터 넘치지 않게 수정, 전체 옵션 추가
- 메인 empty 컴포넌트가 바텀시트에서 스크롤되지 않게 수정

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
