### PR TITLE
카카오 회원가입 로그인 시 로딩화면이 뜨는 문제 수정

### DIFF
--- a/src/app/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
+++ b/src/app/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
@@ -50,6 +50,8 @@ const KakaoContainer = () => {
 
             if (termsAgreed) {
               router.replace("/");
+            } else if (!termsAgreed) {
+              setStep("Term");
             }
           },
         }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 최초 회원가입 시 약관 페이지가 보이는것이 아니라 계속 로딩 화면이 뜨는 버그 수정

## 참고 사항

- <!-- 리뷰어가 알아야 할 맥락이나 주의할 점이 있다면 작성해주세요. -->

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
