### PR TITLE
알림 설정 페이지 기능 누락사항 추가

### DIFF
--- a/src/app/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
+++ b/src/app/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
@@ -50,7 +50,7 @@ const KakaoContainer = () => {
 
             if (termsAgreed) {
               router.replace("/");
-            } else if (!termsAgreed) {
+            } else {
               setStep("Term");
             }
           },

--- a/src/app/(route)/mypage/notifications/_components/NotificationSettingItem/NotificationSettingItem.tsx
+++ b/src/app/(route)/mypage/notifications/_components/NotificationSettingItem/NotificationSettingItem.tsx
@@ -7,6 +7,8 @@ import { Icon, ToggleButton } from "@/components/common";
 import NotificationCategory from "../NotificationCategory/NotificationCategory";
 import { NotificationSetting } from "@/api/fetch/notification";
 import { useToggleClick } from "../../_hooks/useToggleClick";
+import { CATEGORY_OPTIONS } from "@/constants";
+import { CategoryType } from "@/types";
 
 interface NotificationSettingItem {
   item: { label: NotificationLabelType; value: NotificationSettingType };
@@ -27,6 +29,11 @@ const NotificationSettingItem = ({
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
   const { handleToggle } = useToggleClick(notificationStatus);
+
+  const getLabelByValue = (value: CategoryType) => {
+    return CATEGORY_OPTIONS.find((option) => option.value === value)?.label;
+  };
+
   return (
     <>
       <li className="w-full px-5 py-2">
@@ -42,7 +49,9 @@ const NotificationSettingItem = ({
               className="flex w-full items-center justify-between"
             >
               <span className="my-[10px] ml-[10px] text-body1-medium text-neutral-normal-placeholder">
-                카테고리 키워드 선택
+                {notificationStatus.enabledCategories
+                  .map((item) => getLabelByValue(item))
+                  .join(", ") || "카테고리 키워드 선택"}
               </span>
               <Icon name="ArrowRightSmall" size={24} className="text-neutral-strong-default" />
             </button>

--- a/src/app/(route)/mypage/notifications/_components/NotificationSettingItem/NotificationSettingItem.tsx
+++ b/src/app/(route)/mypage/notifications/_components/NotificationSettingItem/NotificationSettingItem.tsx
@@ -48,7 +48,12 @@ const NotificationSettingItem = ({
               onClick={() => setIsBottomSheetOpen(true)}
               className="flex w-full items-center justify-between"
             >
-              <span className="my-[10px] ml-[10px] text-body1-medium text-neutral-normal-placeholder">
+              <span
+                className={cn(
+                  "my-[10px] ml-[10px] text-body1-medium text-neutral-normal-placeholder",
+                  notificationStatus.enabledCategories && "text-neutral-normal-default"
+                )}
+              >
                 {notificationStatus.enabledCategories
                   .map((item) => getLabelByValue(item))
                   .join(", ") || "카테고리 키워드 선택"}

--- a/src/app/(route)/mypage/notifications/_components/NotificationSettingList/NotificationSettingList.tsx
+++ b/src/app/(route)/mypage/notifications/_components/NotificationSettingList/NotificationSettingList.tsx
@@ -53,18 +53,6 @@ const NotificationSettingList = () => {
           );
         })}
       </div>
-
-      <li className="w-full border-t border-border-neutral-normal-default px-5 pb-2 pt-4">
-        <div className="flex h-11 w-full items-center justify-between">
-          <h3 className="text-h3-semibold text-neutral-normal-default">마케팅 수신 동의</h3>
-
-          <ToggleButton
-            ariaLabel="마케팅 수신 동의"
-            toggleState={toggleState?.marketingConsent ?? false}
-            onClick={() => handleToggle("marketingConsent")}
-          />
-        </div>
-      </li>
     </ul>
   );
 };


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 알림 설정 페이지 카테고리 키워드 선택 시 선택한 카테고리로 텍스트 변경
<img width="738" height="529" alt="image" src="https://github.com/user-attachments/assets/f73d48a9-80fb-44b0-9ae5-c2fc6a3fb5c2" />
- 마케팅 수신 동의 제거
- 지난번pr에서 재미나이가 코멘트 해줬던 부분 수정했습니다.

## 참고 사항

- <!-- 리뷰어가 알아야 할 맥락이나 주의할 점이 있다면 작성해주세요. -->

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
