### PR TITLE
메인 지도 위치 에러 및 바텀시트 반복 렌더링 문제 해결

### DIFF
--- a/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
+++ b/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from "@/components/common";
 import { PopupLayout } from "@/components/domain";
 import { useToast } from "@/context/ToastContext";
 import { useMainKakaoMapStore } from "@/store";
+import { clearMainGeoSessionConfirmed, markMainGeoSessionConfirmed } from "@/utils/mainGeoSession";
 import { useState } from "react";
 import { PERMISSION_CONFIG, PERMISSION_ITEM } from "../../_constants/PERMISSION_CONFIG";
 
@@ -31,12 +32,14 @@ const DetailPermissionSheet = ({ isOpen, onClose, state }: DetailPermissionSheet
           useMainKakaoMapStore.getState().triggerLevelReset();
           useMainKakaoMapStore.getState().setUserGpsFromDevice(next);
           useMainKakaoMapStore.getState().setLatLng(next);
+          markMainGeoSessionConfirmed();
           onClose();
         },
         (error) => {
           useMainKakaoMapStore.getState().triggerLevelReset();
           useMainKakaoMapStore.getState().clearLatLng();
           if (error.code === error.PERMISSION_DENIED) {
+            clearMainGeoSessionConfirmed();
             addToast("위치 권한이 거부되었습니다. 설정에서 허용해주세요.", "warning");
           }
           onClose();

--- a/src/app/(home)/_hooks/useMainKakaoMap.ts
+++ b/src/app/(home)/_hooks/useMainKakaoMap.ts
@@ -1,37 +1,95 @@
 import { DEFAULT_LAT_LNG } from "@/constants";
 import { useMainKakaoMapStore } from "@/store";
+import {
+  clearMainGeoSessionConfirmed,
+  hasMainGeoSessionConfirmed,
+  markMainGeoSessionConfirmed,
+} from "@/utils/mainGeoSession";
 import { useEffect, useRef, useState } from "react";
 
 const useMainKakaoMap = () => {
-  const { latLng, setLatLng, clearLatLng, levelResetSignal, mapLevel, setMapLevel } =
-    useMainKakaoMapStore();
+  const {
+    latLng,
+    setLatLng,
+    clearLatLng,
+    levelResetSignal,
+    mapLevel,
+    setMapLevel,
+    setUserGpsFromDevice,
+    triggerLevelReset,
+  } = useMainKakaoMapStore();
   const [isPermissionResolved, setIsPermissionResolved] = useState(false);
   const [mapCenter, setMapCenter] = useState(DEFAULT_LAT_LNG);
   const mapLevelRef = useRef(mapLevel);
   const prevLevelResetSignalRef = useRef(levelResetSignal);
 
   useEffect(() => {
+    const applyGpsToMap = (next: { lat: number; lng: number }) => {
+      triggerLevelReset();
+      setUserGpsFromDevice(next);
+      setLatLng(next);
+      markMainGeoSessionConfirmed();
+    };
+
     const syncCenterByPermission = async () => {
+      if (!navigator.geolocation) {
+        setIsPermissionResolved(true);
+        return;
+      }
+
       if (!navigator.permissions) {
+        if (hasMainGeoSessionConfirmed()) {
+          navigator.geolocation.getCurrentPosition(
+            ({ coords }) => {
+              applyGpsToMap({ lat: coords.latitude, lng: coords.longitude });
+              setIsPermissionResolved(true);
+            },
+            (error) => {
+              if (error.code === error.PERMISSION_DENIED) {
+                clearMainGeoSessionConfirmed();
+                clearLatLng();
+              }
+              setIsPermissionResolved(true);
+            }
+          );
+          return;
+        }
         setIsPermissionResolved(true);
         return;
       }
 
-      const permission = await navigator.permissions.query({ name: "geolocation" });
-      const isLocationDenied = permission.state === "denied";
+      try {
+        const permission = await navigator.permissions.query({ name: "geolocation" });
 
-      if (isLocationDenied) {
-        clearLatLng();
-        setMapCenter(DEFAULT_LAT_LNG);
+        if (permission.state === "denied") {
+          clearMainGeoSessionConfirmed();
+          clearLatLng();
+          setIsPermissionResolved(true);
+          return;
+        }
+
+        if (permission.state === "granted") {
+          navigator.geolocation.getCurrentPosition(
+            ({ coords }) => {
+              applyGpsToMap({ lat: coords.latitude, lng: coords.longitude });
+              setIsPermissionResolved(true);
+            },
+            () => {
+              clearLatLng();
+              setIsPermissionResolved(true);
+            }
+          );
+          return;
+        }
+
         setIsPermissionResolved(true);
-        return;
+      } catch {
+        setIsPermissionResolved(true);
       }
-
-      setIsPermissionResolved(true);
     };
 
     void syncCenterByPermission();
-  }, [clearLatLng]);
+  }, [clearLatLng, setLatLng, setUserGpsFromDevice, triggerLevelReset]);
 
   useEffect(() => {
     if (!isPermissionResolved) return;

--- a/src/app/(home)/_hooks/useMyLocationButton.ts
+++ b/src/app/(home)/_hooks/useMyLocationButton.ts
@@ -1,4 +1,9 @@
 import { useMainKakaoMapStore } from "@/store";
+import {
+  clearMainGeoSessionConfirmed,
+  hasMainGeoSessionConfirmed,
+  markMainGeoSessionConfirmed,
+} from "@/utils/mainGeoSession";
 import { useCallback, useEffect, useState } from "react";
 
 const useMyLocationButton = () => {
@@ -21,6 +26,7 @@ const useMyLocationButton = () => {
 
       if (permission.state === "denied") {
         clearLatLng();
+        clearMainGeoSessionConfirmed();
       }
     };
 
@@ -39,10 +45,14 @@ const useMyLocationButton = () => {
         const next = { lat: coords.latitude, lng: coords.longitude };
         setUserGpsFromDevice(next);
         setLatLng(next);
+        markMainGeoSessionConfirmed();
       },
-      () => {
+      (error) => {
         triggerLevelReset();
         clearLatLng();
+        if (error.code === error.PERMISSION_DENIED) {
+          clearMainGeoSessionConfirmed();
+        }
       }
     );
   }, [clearLatLng, setLatLng, setUserGpsFromDevice, triggerLevelReset]);
@@ -60,15 +70,32 @@ const useMyLocationButton = () => {
           requestDeviceLocation();
           return;
         }
+        if (result.state === "denied") {
+          setIsLocationPermissionSheetOpen(true);
+          return;
+        }
+        if (hasMainGeoSessionConfirmed()) {
+          requestDeviceLocation();
+          return;
+        }
         setIsLocationPermissionSheetOpen(true);
         return;
       } catch {
-        requestDeviceLocation();
+        if (hasMainGeoSessionConfirmed()) {
+          requestDeviceLocation();
+          return;
+        }
+        setIsLocationPermissionSheetOpen(true);
         return;
       }
     }
 
-    requestDeviceLocation();
+    if (hasMainGeoSessionConfirmed()) {
+      requestDeviceLocation();
+      return;
+    }
+
+    setIsLocationPermissionSheetOpen(true);
   };
 
   const closeLocationPermissionSheet = useCallback(() => {

--- a/src/constants/GEO_SESSION.ts
+++ b/src/constants/GEO_SESSION.ts
@@ -1,0 +1,2 @@
+/** 메인 지도에서 브라우저 위치 권한이 한 번이라도 성공한 뒤 세션 동안 바텀시트를 생략하기 위한 키 */
+export const MAIN_GEO_SESSION_KEY = "fmi-main-geolocation-confirmed";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,4 +2,5 @@ export * from "./FIND_PW_ERROR";
 export * from "./PUBLIC_DATA_CODES";
 export * from "./CATEGORY_OPTIONS";
 export * from "./DEFAULT_MAP_DATA";
+export * from "./GEO_SESSION";
 export * from "./AUTH_EVENTS";

--- a/src/utils/mainGeoSession.ts
+++ b/src/utils/mainGeoSession.ts
@@ -1,0 +1,28 @@
+import { MAIN_GEO_SESSION_KEY } from "@/constants/GEO_SESSION";
+
+export function markMainGeoSessionConfirmed(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.setItem(MAIN_GEO_SESSION_KEY, "1");
+  } catch {
+    // ignore
+  }
+}
+
+export function hasMainGeoSessionConfirmed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return sessionStorage.getItem(MAIN_GEO_SESSION_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function clearMainGeoSessionConfirmed(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(MAIN_GEO_SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #970
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 사용자 위치가 허용한 상태에서 기본 위치가 서울 시청으로 뜨는 문제
위치 허용을 한 상태에서 위치 포지션 버튼을 누를 떄마다 위치 허용 바텀시트가 계속 렌더링되는 문제
를 수정했습니다.

## 참고 사항

- 릴리즈 환경 맥 PC/모바일, 윈도우 PC/모바일, PWA 모두 정상 동작 확인해야 합니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
