### PR TITLE
PWA 알림 구현

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-restricted-globals */
+/* global self, clients */
+
+self.addEventListener("push", (event) => {
+  let title = "찾아줘!";
+  let body = "";
+  let url = "/";
+
+  if (event.data) {
+    try {
+      const payload = event.data.json();
+      title = payload.title ?? payload.notification?.title ?? payload.subject ?? title;
+      body = payload.body ?? payload.message ?? payload.content ?? payload.notification?.body ?? "";
+      url = payload.url ?? payload.link ?? payload.click_action ?? payload.data?.url ?? "/";
+    } catch {
+      try {
+        const text = event.data.text();
+        if (text) body = text;
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  const options = {
+    body,
+    icon: "/pwa/icon-192.png",
+    badge: "/favicon/default/favicon-48.png",
+    data: { url },
+    vibrate: [120, 80, 120],
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const raw = event.notification?.data?.url || "/";
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clientList) => {
+      let openUrl = raw;
+      if (typeof raw === "string" && !raw.startsWith("http")) {
+        openUrl = self.location.origin + (raw.startsWith("/") ? raw : "/" + raw);
+      }
+
+      for (const client of clientList) {
+        if (client.url.startsWith(self.location.origin) && "focus" in client) {
+          return client.focus();
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(openUrl);
+      }
+    })
+  );
+});

--- a/src/api/fetch/webPush/api/useDeletePushSubscribe.ts
+++ b/src/api/fetch/webPush/api/useDeletePushSubscribe.ts
@@ -1,0 +1,10 @@
+import useAppMutation from "@/api/_base/query/useAppMutation";
+import { DeletePushSubscribeResponse, DeletePushSubscribeVariables } from "../types/webPushType";
+
+export const useDeletePushSubscribe = () => {
+  return useAppMutation<DeletePushSubscribeVariables, DeletePushSubscribeResponse>(
+    "auth",
+    ({ endpoint }) => `/push/subscribe?endpoint=${encodeURIComponent(endpoint)}`,
+    "delete"
+  );
+};

--- a/src/api/fetch/webPush/api/useGetPushVapidKey.ts
+++ b/src/api/fetch/webPush/api/useGetPushVapidKey.ts
@@ -1,0 +1,11 @@
+import useAppQuery from "@/api/_base/query/useAppQuery";
+import { GetPushVapidKeyResponse } from "../types/webPushType";
+
+export const useGetPushVapidKey = (options?: { enabled?: boolean }) => {
+  return useAppQuery<GetPushVapidKeyResponse, unknown>(
+    "public",
+    ["/push/vapid-key"],
+    "/push/vapid-key",
+    options
+  );
+};

--- a/src/api/fetch/webPush/api/usePostPushSubscribe.ts
+++ b/src/api/fetch/webPush/api/usePostPushSubscribe.ts
@@ -1,0 +1,10 @@
+import useAppMutation from "@/api/_base/query/useAppMutation";
+import { PostPushSubscribeRequest, PostPushSubscribeResponse } from "../types/webPushType";
+
+export const usePostPushSubscribe = () => {
+  return useAppMutation<PostPushSubscribeRequest, PostPushSubscribeResponse>(
+    "auth",
+    "/push/subscribe",
+    "post"
+  );
+};

--- a/src/api/fetch/webPush/index.ts
+++ b/src/api/fetch/webPush/index.ts
@@ -1,0 +1,5 @@
+export * from "./types/webPushType";
+
+export { usePostPushSubscribe } from "./api/usePostPushSubscribe";
+export { useDeletePushSubscribe } from "./api/useDeletePushSubscribe";
+export { useGetPushVapidKey } from "./api/useGetPushVapidKey";

--- a/src/api/fetch/webPush/types/webPushType.ts
+++ b/src/api/fetch/webPush/types/webPushType.ts
@@ -1,0 +1,21 @@
+import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
+
+export interface PostPushSubscribeRequest {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+export interface PostPushSubscribeResponse extends ApiBaseResponseType<string> {}
+
+export interface DeletePushSubscribeVariables {
+  endpoint: string;
+}
+
+export interface DeletePushSubscribeResponse extends ApiBaseResponseType<string> {}
+
+export type PushVapidKeyResult = Record<string, string>;
+
+export interface GetPushVapidKeyResponse extends ApiBaseResponseType<PushVapidKeyResult> {}

--- a/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
+++ b/src/app/(home)/_components/PermissionBottomSheet/PermissionBottomSheet.tsx
@@ -6,6 +6,7 @@ import { useMainKakaoMapStore } from "@/store";
 import { clearMainGeoSessionConfirmed, markMainGeoSessionConfirmed } from "@/utils/mainGeoSession";
 import { useState } from "react";
 import { PERMISSION_CONFIG, PERMISSION_ITEM } from "../../_constants/PERMISSION_CONFIG";
+import { syncWebPushSubscription } from "@/utils";
 
 interface DetailPermissionSheetProps {
   isOpen: boolean;
@@ -53,7 +54,16 @@ const DetailPermissionSheet = ({ isOpen, onClose, state }: DetailPermissionSheet
       }
 
       if (Notification.permission === "granted") {
-        updateNotification({ browserNotificationEnabled: true });
+        updateNotification(
+          { browserNotificationEnabled: true },
+          {
+            onSuccess: () => {
+              void syncWebPushSubscription().catch(() =>
+                addToast("브라우저 알림 등록에 실패했어요", "warning")
+              );
+            },
+          }
+        );
         onClose();
         return;
       }
@@ -66,7 +76,16 @@ const DetailPermissionSheet = ({ isOpen, onClose, state }: DetailPermissionSheet
 
       const permission = await Notification.requestPermission();
       if (permission === "granted") {
-        updateNotification({ browserNotificationEnabled: true });
+        updateNotification(
+          { browserNotificationEnabled: true },
+          {
+            onSuccess: () => {
+              void syncWebPushSubscription().catch(() =>
+                addToast("브라우저 알림 등록에 실패했어요", "warning")
+              );
+            },
+          }
+        );
       }
       onClose();
     }

--- a/src/app/(route)/mypage/notifications/_hooks/useToggleClick.ts
+++ b/src/app/(route)/mypage/notifications/_hooks/useToggleClick.ts
@@ -3,6 +3,7 @@ import { NotificationSettingType } from "../_types/NotificationType";
 import { NotificationSetting } from "@/api/fetch/notification";
 import { useToast } from "@/context/ToastContext";
 import { useCallback } from "react";
+import { syncWebPushSubscription, unsubscribeWebPushFromServer } from "@/utils";
 
 export const useToggleClick = (notificationData?: NotificationSetting) => {
   const { mutate: notificationMutate, isPending } = usePutNotificationSetting();
@@ -14,6 +15,18 @@ export const useToggleClick = (notificationData?: NotificationSetting) => {
 
       const currentStatus = notificationData?.[settingName];
       const nextState = !currentStatus;
+
+      if (settingName === "browserNotificationEnabled" && nextState === false) {
+        notificationMutate(
+          { browserNotificationEnabled: false },
+          {
+            onSuccess: () => {
+              void unsubscribeWebPushFromServer().catch(() => {});
+            },
+          }
+        );
+        return;
+      }
 
       if (settingName === "browserNotificationEnabled" && nextState === true) {
         if (!("Notification" in window)) {
@@ -27,6 +40,18 @@ export const useToggleClick = (notificationData?: NotificationSetting) => {
           addToast("알림 권한이 거절되었어요", "warning");
           return;
         }
+
+        notificationMutate(
+          { browserNotificationEnabled: true },
+          {
+            onSuccess: () => {
+              void syncWebPushSubscription().catch(() => {
+                addToast("브라우저 알림 등록에 실패했어요", "warning");
+              });
+            },
+          }
+        );
+        return;
       }
 
       notificationMutate({ [settingName]: nextState });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import AuthBootstrap from "./authBootStrap";
 import { NotificationSSEProvider } from "@/providers/NotificationSSEProvider";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { PWAProvider } from "@/providers/PWAProvider";
+import { WebPushProvider } from "@/providers/WebPushProvider";
 import TermsProvider from "@/providers/TermsProvider";
 
 const pretendard = localFont({
@@ -91,10 +92,12 @@ export default function RootLayout({
                 <ToastProvider>
                   <MSWProvider />
                   <AuthBootstrap />
-                  <NotificationSSEProvider>
-                    <main className="w-full flex-1">{children}</main>
-                    <Footer />
-                  </NotificationSSEProvider>
+                  <WebPushProvider>
+                    <NotificationSSEProvider>
+                      <main className="w-full flex-1">{children}</main>
+                      <Footer />
+                    </NotificationSSEProvider>
+                  </WebPushProvider>
                 </ToastProvider>
               </TermsProvider>
             </SnackBarProvider>

--- a/src/hooks/useLogout/useLogout.ts
+++ b/src/hooks/useLogout/useLogout.ts
@@ -3,6 +3,7 @@ import { disconnectNotificationSSE } from "@/api/fetch/notification/api/notifica
 import { useToast } from "@/context/ToastContext";
 import { useAgreeStore, useNotificationStore } from "@/store";
 import { useQueryClient } from "@tanstack/react-query";
+import { WEB_PUSH_UNSUBSCRIBE_BEFORE_LOGOUT_TIMEOUT_MS } from "@/utils/webPush/webPushConstants";
 import { unsubscribeWebPushFromServer } from "@/utils";
 
 const useLogout = () => {
@@ -20,7 +21,15 @@ const useLogout = () => {
 
     void (async () => {
       try {
-        await unsubscribeWebPushFromServer();
+        await Promise.race([
+          unsubscribeWebPushFromServer(),
+          new Promise<void>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("web-push-unsubscribe-timeout")),
+              WEB_PUSH_UNSUBSCRIBE_BEFORE_LOGOUT_TIMEOUT_MS
+            )
+          ),
+        ]);
       } catch {
         // ignore
       }

--- a/src/hooks/useLogout/useLogout.ts
+++ b/src/hooks/useLogout/useLogout.ts
@@ -3,6 +3,7 @@ import { disconnectNotificationSSE } from "@/api/fetch/notification/api/notifica
 import { useToast } from "@/context/ToastContext";
 import { useAgreeStore, useNotificationStore } from "@/store";
 import { useQueryClient } from "@tanstack/react-query";
+import { unsubscribeWebPushFromServer } from "@/utils";
 
 const useLogout = () => {
   const { mutate: logoutMutate, isPending } = useApiLogout();
@@ -17,19 +18,27 @@ const useLogout = () => {
   const handleLogout = () => {
     if (isPending) return;
 
-    logoutMutate(undefined, {
-      onSuccess: () => {
-        disconnectNotificationSSE();
-        resetUnreadNotificationState();
-        queryClient.clear();
-        logout();
-        addToast("로그아웃 되었어요.", "success");
-        window.location.href = "/";
-      },
-      onError: () => {
-        addToast("로그아웃에 실패했어요. 다시 시도해주세요.", "error");
-      },
-    });
+    void (async () => {
+      try {
+        await unsubscribeWebPushFromServer();
+      } catch {
+        // ignore
+      }
+
+      logoutMutate(undefined, {
+        onSuccess: () => {
+          disconnectNotificationSSE();
+          resetUnreadNotificationState();
+          queryClient.clear();
+          logout();
+          addToast("로그아웃 되었어요.", "success");
+          window.location.href = "/";
+        },
+        onError: () => {
+          addToast("로그아웃에 실패했어요. 다시 시도해주세요.", "error");
+        },
+      });
+    })();
   };
 
   return { handleLogout, isPending };

--- a/src/providers/WebPushProvider.tsx
+++ b/src/providers/WebPushProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { PropsWithChildren, useEffect } from "react";
+import { useGetNotificationSetting } from "@/api/fetch/notification";
+import { useAgreeStore, useAuthStore } from "@/store";
+import { isWebPushSupported, registerWebPushServiceWorker, syncWebPushSubscription } from "@/utils";
+
+export const WebPushProvider = ({ children }: PropsWithChildren) => {
+  const isLoggedIn = useAgreeStore((s) => s.isLoggedIn);
+  const isAuthInitialized = useAuthStore((s) => s.isAuthInitialized);
+
+  const { data: notificationSetting } = useGetNotificationSetting({
+    enabled: isLoggedIn && isAuthInitialized,
+  });
+
+  useEffect(() => {
+    void registerWebPushServiceWorker();
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn || !isAuthInitialized) return;
+
+    const browserPushOn = notificationSetting?.result?.browserNotificationEnabled;
+    if (!browserPushOn) return;
+    if (typeof Notification === "undefined" || Notification.permission !== "granted") return;
+    if (!isWebPushSupported()) return;
+
+    void (async () => {
+      try {
+        await syncWebPushSubscription();
+      } catch (e) {
+        if (process.env.NODE_ENV === "development") {
+          console.warn("[WebPushProvider] syncWebPushSubscription:", e);
+        }
+      }
+    })();
+  }, [isLoggedIn, isAuthInitialized, notificationSetting?.result?.browserNotificationEnabled]);
+
+  return children;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,3 +27,7 @@ export { retryBackoffController } from "./retryBackoffController/retryBackoffCon
 export { formatMetadataKeyword } from "./formatMetadataKeyword/formatMetadataKeyword";
 export { formatMetadataAddress } from "./formatMetadataAddress/formatMetadataAddress";
 export { extractDongAddress } from "./extractDongAddress/extractDongAddress";
+export { isWebPushSupported } from "./webPush/isWebPushSupported";
+export { registerWebPushServiceWorker } from "./webPush/registerWebPushServiceWorker";
+export { syncWebPushSubscription } from "./webPush/syncWebPushSubscription";
+export { unsubscribeWebPushFromServer } from "./webPush/unsubscribeWebPushFromServer";

--- a/src/utils/webPush/isWebPushSupported.ts
+++ b/src/utils/webPush/isWebPushSupported.ts
@@ -1,0 +1,7 @@
+export function isWebPushSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  if (!window.isSecureContext) return false;
+  if (!("serviceWorker" in navigator)) return false;
+  if (!("PushManager" in window)) return false;
+  return true;
+}

--- a/src/utils/webPush/isWebPushSupported.ts
+++ b/src/utils/webPush/isWebPushSupported.ts
@@ -1,7 +1,7 @@
-export function isWebPushSupported(): boolean {
+export const isWebPushSupported = (): boolean => {
   if (typeof window === "undefined") return false;
   if (!window.isSecureContext) return false;
   if (!("serviceWorker" in navigator)) return false;
   if (!("PushManager" in window)) return false;
   return true;
-}
+};

--- a/src/utils/webPush/pickVapidPublicKey.ts
+++ b/src/utils/webPush/pickVapidPublicKey.ts
@@ -1,3 +1,5 @@
+import { VAPID_PUBLIC_KEY_STRING_MIN_LENGTH_HEURISTIC } from "./webPushConstants";
+
 const VAPID_PUBLIC_KEY_FIELD_CANDIDATES = [
   "publicKey",
   "public_key",
@@ -11,7 +13,9 @@ export const pickVapidPublicKey = (result: Record<string, string>): string => {
     if (value && value.length > 0) return value;
   }
 
-  const values = Object.values(result).filter((v) => typeof v === "string" && v.length >= 80);
+  const values = Object.values(result).filter(
+    (v) => typeof v === "string" && v.length >= VAPID_PUBLIC_KEY_STRING_MIN_LENGTH_HEURISTIC
+  );
   if (values.length > 0) return values[0];
 
   throw new Error("VAPID public key not found in response");

--- a/src/utils/webPush/pickVapidPublicKey.ts
+++ b/src/utils/webPush/pickVapidPublicKey.ts
@@ -1,0 +1,18 @@
+const VAPID_PUBLIC_KEY_FIELD_CANDIDATES = [
+  "publicKey",
+  "public_key",
+  "vapidPublicKey",
+  "applicationServerKey",
+] as const;
+
+export function pickVapidPublicKey(result: Record<string, string>): string {
+  for (const key of VAPID_PUBLIC_KEY_FIELD_CANDIDATES) {
+    const value = result[key];
+    if (value && value.length > 0) return value;
+  }
+
+  const values = Object.values(result).filter((v) => typeof v === "string" && v.length >= 80);
+  if (values.length > 0) return values[0];
+
+  throw new Error("VAPID public key not found in response");
+}

--- a/src/utils/webPush/pickVapidPublicKey.ts
+++ b/src/utils/webPush/pickVapidPublicKey.ts
@@ -5,7 +5,7 @@ const VAPID_PUBLIC_KEY_FIELD_CANDIDATES = [
   "applicationServerKey",
 ] as const;
 
-export function pickVapidPublicKey(result: Record<string, string>): string {
+export const pickVapidPublicKey = (result: Record<string, string>): string => {
   for (const key of VAPID_PUBLIC_KEY_FIELD_CANDIDATES) {
     const value = result[key];
     if (value && value.length > 0) return value;
@@ -15,4 +15,4 @@ export function pickVapidPublicKey(result: Record<string, string>): string {
   if (values.length > 0) return values[0];
 
   throw new Error("VAPID public key not found in response");
-}
+};

--- a/src/utils/webPush/registerWebPushServiceWorker.ts
+++ b/src/utils/webPush/registerWebPushServiceWorker.ts
@@ -2,7 +2,7 @@ import { shouldRegisterWebPushServiceWorker } from "./shouldRegisterWebPushServi
 
 const WEB_PUSH_SERVICE_WORKER_URL = "/sw.js";
 
-export async function registerWebPushServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+export const registerWebPushServiceWorker = async (): Promise<ServiceWorkerRegistration | null> => {
   if (!("serviceWorker" in navigator)) return null;
   if (!shouldRegisterWebPushServiceWorker()) return null;
 
@@ -11,4 +11,4 @@ export async function registerWebPushServiceWorker(): Promise<ServiceWorkerRegis
   } catch {
     return null;
   }
-}
+};

--- a/src/utils/webPush/registerWebPushServiceWorker.ts
+++ b/src/utils/webPush/registerWebPushServiceWorker.ts
@@ -1,0 +1,14 @@
+import { shouldRegisterWebPushServiceWorker } from "./shouldRegisterWebPushServiceWorker";
+
+const WEB_PUSH_SERVICE_WORKER_URL = "/sw.js";
+
+export async function registerWebPushServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!("serviceWorker" in navigator)) return null;
+  if (!shouldRegisterWebPushServiceWorker()) return null;
+
+  try {
+    return await navigator.serviceWorker.register(WEB_PUSH_SERVICE_WORKER_URL, { scope: "/" });
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/webPush/shouldRegisterWebPushServiceWorker.ts
+++ b/src/utils/webPush/shouldRegisterWebPushServiceWorker.ts
@@ -1,0 +1,4 @@
+export function shouldRegisterWebPushServiceWorker(): boolean {
+  if (typeof window === "undefined") return false;
+  return process.env.NEXT_PUBLIC_API_MOCKING !== "enabled";
+}

--- a/src/utils/webPush/shouldRegisterWebPushServiceWorker.ts
+++ b/src/utils/webPush/shouldRegisterWebPushServiceWorker.ts
@@ -1,4 +1,4 @@
-export function shouldRegisterWebPushServiceWorker(): boolean {
+export const shouldRegisterWebPushServiceWorker = (): boolean => {
   if (typeof window === "undefined") return false;
   return process.env.NEXT_PUBLIC_API_MOCKING !== "enabled";
-}
+};

--- a/src/utils/webPush/syncWebPushSubscription.ts
+++ b/src/utils/webPush/syncWebPushSubscription.ts
@@ -9,7 +9,7 @@ import { registerWebPushServiceWorker } from "./registerWebPushServiceWorker";
 import { isWebPushSupported } from "./isWebPushSupported";
 import { urlBase64ToUint8Array } from "./urlBase64ToUint8Array";
 
-export async function syncWebPushSubscription(): Promise<void> {
+export const syncWebPushSubscription = async (): Promise<void> => {
   if (!isWebPushSupported()) {
     throw new Error("Web Push is not supported in this environment");
   }
@@ -46,4 +46,4 @@ export async function syncWebPushSubscription(): Promise<void> {
   if (!subRes?.isSuccess) {
     throw new Error("Failed to register push subscription on server");
   }
-}
+};

--- a/src/utils/webPush/syncWebPushSubscription.ts
+++ b/src/utils/webPush/syncWebPushSubscription.ts
@@ -1,0 +1,49 @@
+import publicApi from "@/api/_base/axios/publicApi";
+import authApi from "@/api/_base/axios/authApi";
+import type {
+  GetPushVapidKeyResponse,
+  PostPushSubscribeRequest,
+} from "@/api/fetch/webPush/types/webPushType";
+import { pickVapidPublicKey } from "./pickVapidPublicKey";
+import { registerWebPushServiceWorker } from "./registerWebPushServiceWorker";
+import { isWebPushSupported } from "./isWebPushSupported";
+import { urlBase64ToUint8Array } from "./urlBase64ToUint8Array";
+
+export async function syncWebPushSubscription(): Promise<void> {
+  if (!isWebPushSupported()) {
+    throw new Error("Web Push is not supported in this environment");
+  }
+
+  await registerWebPushServiceWorker();
+  const registration = await navigator.serviceWorker.ready;
+
+  const { data: vapidRes } = await publicApi.get<GetPushVapidKeyResponse>("/push/vapid-key");
+  if (!vapidRes?.isSuccess || !vapidRes.result) {
+    throw new Error("Failed to load VAPID public key");
+  }
+
+  const applicationServerKey = urlBase64ToUint8Array(pickVapidPublicKey(vapidRes.result));
+
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: applicationServerKey as BufferSource,
+  });
+
+  const json = subscription.toJSON();
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error("Invalid PushSubscription keys");
+  }
+
+  const body: PostPushSubscribeRequest = {
+    endpoint: json.endpoint,
+    keys: {
+      p256dh: json.keys.p256dh,
+      auth: json.keys.auth,
+    },
+  };
+
+  const { data: subRes } = await authApi.post("/push/subscribe", body);
+  if (!subRes?.isSuccess) {
+    throw new Error("Failed to register push subscription on server");
+  }
+}

--- a/src/utils/webPush/syncWebPushSubscription.ts
+++ b/src/utils/webPush/syncWebPushSubscription.ts
@@ -10,12 +10,10 @@ import { isWebPushSupported } from "./isWebPushSupported";
 import { urlBase64ToUint8Array } from "./urlBase64ToUint8Array";
 
 export const syncWebPushSubscription = async (): Promise<void> => {
-  if (!isWebPushSupported()) {
-    throw new Error("Web Push is not supported in this environment");
-  }
+  if (!isWebPushSupported()) return;
 
-  await registerWebPushServiceWorker();
-  const registration = await navigator.serviceWorker.ready;
+  const registration = await registerWebPushServiceWorker();
+  if (!registration) return;
 
   const { data: vapidRes } = await publicApi.get<GetPushVapidKeyResponse>("/push/vapid-key");
   if (!vapidRes?.isSuccess || !vapidRes.result) {

--- a/src/utils/webPush/unsubscribeWebPushFromServer.ts
+++ b/src/utils/webPush/unsubscribeWebPushFromServer.ts
@@ -1,0 +1,25 @@
+import authApi from "@/api/_base/axios/authApi";
+import { isWebPushSupported } from "./isWebPushSupported";
+
+export async function unsubscribeWebPushFromServer(): Promise<void> {
+  if (!isWebPushSupported()) return;
+  if (!("serviceWorker" in navigator)) return;
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (!registration) return;
+
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) return;
+
+  const endpoint = subscription.endpoint;
+
+  try {
+    await authApi.delete(`/push/subscribe?endpoint=${encodeURIComponent(endpoint)}`);
+  } finally {
+    try {
+      await subscription.unsubscribe();
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/utils/webPush/unsubscribeWebPushFromServer.ts
+++ b/src/utils/webPush/unsubscribeWebPushFromServer.ts
@@ -1,7 +1,7 @@
 import authApi from "@/api/_base/axios/authApi";
 import { isWebPushSupported } from "./isWebPushSupported";
 
-export async function unsubscribeWebPushFromServer(): Promise<void> {
+export const unsubscribeWebPushFromServer = async (): Promise<void> => {
   if (!isWebPushSupported()) return;
   if (!("serviceWorker" in navigator)) return;
 
@@ -22,4 +22,4 @@ export async function unsubscribeWebPushFromServer(): Promise<void> {
       // ignore
     }
   }
-}
+};

--- a/src/utils/webPush/urlBase64ToUint8Array.ts
+++ b/src/utils/webPush/urlBase64ToUint8Array.ts
@@ -1,0 +1,10 @@
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const output = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i += 1) {
+    output[i] = rawData.charCodeAt(i);
+  }
+  return output;
+}

--- a/src/utils/webPush/urlBase64ToUint8Array.ts
+++ b/src/utils/webPush/urlBase64ToUint8Array.ts
@@ -1,4 +1,4 @@
-export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+export const urlBase64ToUint8Array = (base64String: string): Uint8Array => {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const rawData = atob(base64);
@@ -7,4 +7,4 @@ export function urlBase64ToUint8Array(base64String: string): Uint8Array {
     output[i] = rawData.charCodeAt(i);
   }
   return output;
-}
+};

--- a/src/utils/webPush/webPushConstants.ts
+++ b/src/utils/webPush/webPushConstants.ts
@@ -1,0 +1,11 @@
+/**
+ * pickVapidPublicKey: 알려진 필드명이 없을 때, 값이 VAPID 공개키(일반적으로 URL-safe Base64)로
+ * 보이는지 판별하기 위한 최소 문자열 길이 휴리스틱입니다.
+ */
+export const VAPID_PUBLIC_KEY_STRING_MIN_LENGTH_HEURISTIC = 80;
+
+/**
+ * 로그아웃 API 호출 전 푸시 구독 해제(DELETE) 대기 상한(ms).
+ * 초과 시 로그아웃은 진행하며, 이미 세션이 끊긴 뒤에는 구독 해제가 실패할 수 있습니다.
+ */
+export const WEB_PUSH_UNSUBSCRIBE_BEFORE_LOGOUT_TIMEOUT_MS = 4_000;


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #973
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 웹 푸쉬 API 구현
- PWA 연동 및 기존 SSE 충돌 방지 코드 작성, 로그아웃 로직 작성

## 참고 사항

- 릴리즈 서버에서 웹 푸쉬 테스트 후 본 서버로 머지하여 웹/PWA 웹푸쉬 알림 기능이 정상 동작하는지 확인해야 합니다.
- TSDoc 및 테스트 코드, 폴더 구조는 이후 작업에서 같이 정리하도록 하겠습니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
