### PR TITLE
Sentry 이슈 발생 시 GitHub 이슈 자동 생성 webhook 엔드포인트 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ NEXT_PUBLIC_CLARITY_ID=your_clarity_id
 # Build & CI
 SENTRY_AUTH_TOKEN=your_sentry_auth_token
 CHROMATIC_PROJECT_TOKEN=your_chromatic_project_token
+
+# Sentry Webhook > GitHub Issue
+SENTRY_WEBHOOK_SECRET=your_sentry_webhook_secret
+GITHUB_TOKEN=your_github_personal_access_token

--- a/src/app/api/sentry/webhook/route.ts
+++ b/src/app/api/sentry/webhook/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN!;
+const SENTRY_WEBHOOK_SECRET = process.env.SENTRY_WEBHOOK_SECRET!;
+
+const GITHUB_REPO = "finditem/FI-FE";
+
+function verifySignature(body: string, signature: string): boolean {
+  const hmac = crypto.createHmac("sha256", SENTRY_WEBHOOK_SECRET);
+  const digest = hmac.update(body).digest("hex");
+  const digestBuf = Buffer.from(digest);
+  const signatureBuf = Buffer.from(signature);
+  if (digestBuf.length !== signatureBuf.length) return false;
+  return crypto.timingSafeEqual(digestBuf, signatureBuf);
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const signature = request.headers.get("sentry-hook-signature") ?? "";
+
+  if (!verifySignature(rawBody, signature)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const payload = JSON.parse(rawBody);
+  const issue = payload?.data?.issue;
+
+  if (!issue) {
+    return NextResponse.json({ error: "No issue data" }, { status: 400 });
+  }
+
+  const githubIssueBody = [
+    `## Sentry Issue`,
+    ``,
+    `**Level:** ${issue.level}`,
+    `**Status:** ${issue.status}`,
+    `**Culprit:** ${issue.culprit ?? "unknown"}`,
+    ``,
+    `[Sentry에서 보기](${issue.url})`,
+  ].join("\n");
+
+  const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${GITHUB_TOKEN}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({
+      title: `[Sentry] ${issue.title}`,
+      body: githubIssueBody,
+      labels: ["bug", "sentry"],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    return NextResponse.json({ error }, { status: response.status });
+  }
+
+  const githubIssue = await response.json();
+  return NextResponse.json({ url: githubIssue.html_url }, { status: 201 });
+}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #984
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- Sentry 이슈 발생 시 깃허브 이슈를 자동 생성하는 webhook 엔드포인트 추가
- Next.js route 를 사용하여 webhook URL을 생성했습니다.

## 참고 사항

- .env.example에 예제는 추가되었지만, 로컬에서 테스트가 필요하지 않은 경우 추가하지 않으셔도 됩니다.
- sentry 라벨 추가했습니다.
- main 배포까지 진행 후 curl로 테스트 해보겠습니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
