### PR TITLE
Sentry Webhook 이벤트 payload 처리 로직 수정

### DIFF
--- a/src/app/api/sentry/webhook/route.ts
+++ b/src/app/api/sentry/webhook/route.ts
@@ -6,16 +6,82 @@ const SENTRY_WEBHOOK_SECRET = process.env.SENTRY_WEBHOOK_SECRET!;
 
 const GITHUB_REPO = "finditem/FI-FE";
 
-function verifySignature(body: string, signature: string): boolean {
+type SentryIssue = {
+  title?: string;
+  level?: string;
+  status?: string;
+  culprit?: string | null;
+  url?: string;
+  web_url?: string;
+};
+
+type SentryEvent = {
+  title?: string;
+  message?: string;
+  level?: string;
+  culprit?: string | null;
+  url?: string;
+  web_url?: string;
+  event_id?: string;
+};
+
+type SentryWebhookPayload = {
+  action?: string;
+  installation?: {
+    uuid?: string;
+  };
+  data?: {
+    issue?: SentryIssue;
+    event?: SentryEvent;
+    description?: string;
+    web_url?: string;
+  };
+};
+
+const verifySignature = (body: string, signature: string): boolean => {
+  if (!signature) return false;
+
   const hmac = crypto.createHmac("sha256", SENTRY_WEBHOOK_SECRET);
   const digest = hmac.update(body).digest("hex");
+
   const digestBuf = Buffer.from(digest);
   const signatureBuf = Buffer.from(signature);
-  if (digestBuf.length !== signatureBuf.length) return false;
-  return crypto.timingSafeEqual(digestBuf, signatureBuf);
-}
 
-export async function POST(request: NextRequest) {
+  if (digestBuf.length !== signatureBuf.length) return false;
+
+  return crypto.timingSafeEqual(digestBuf, signatureBuf);
+};
+
+const getSentryData = (payload: SentryWebhookPayload) => {
+  const issue = payload.data?.issue;
+  const event = payload.data?.event;
+
+  const title =
+    issue?.title ??
+    event?.title ??
+    event?.message ??
+    payload.data?.description ??
+    "Unknown Sentry Error";
+
+  const level = issue?.level ?? event?.level ?? "unknown";
+  const status = issue?.status ?? "unknown";
+  const culprit = issue?.culprit ?? event?.culprit ?? "unknown";
+
+  const sentryUrl =
+    issue?.url ?? issue?.web_url ?? event?.web_url ?? event?.url ?? payload.data?.web_url ?? "";
+
+  return {
+    title,
+    level,
+    status,
+    culprit,
+    sentryUrl,
+    eventId: event?.event_id ?? "unknown",
+    action: payload.action ?? "unknown",
+  };
+};
+
+export const POST = async (request: NextRequest) => {
   const rawBody = await request.text();
   const signature = request.headers.get("sentry-hook-signature") ?? "";
 
@@ -23,32 +89,40 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
-  const payload = JSON.parse(rawBody);
-  const issue = payload?.data?.issue;
+  let payload: SentryWebhookPayload;
 
-  if (!issue) {
-    return NextResponse.json({ error: "No issue data" }, { status: 400 });
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
   }
+
+  const sentryData = getSentryData(payload);
 
   const githubIssueBody = [
     `## Sentry Issue`,
     ``,
-    `**Level:** ${issue.level}`,
-    `**Status:** ${issue.status}`,
-    `**Culprit:** ${issue.culprit ?? "unknown"}`,
+    `**Action:** ${sentryData.action}`,
+    `**Level:** ${sentryData.level}`,
+    `**Status:** ${sentryData.status}`,
+    `**Culprit:** ${sentryData.culprit}`,
+    `**Event ID:** ${sentryData.eventId}`,
     ``,
-    `[Sentry에서 보기](${issue.url})`,
+    sentryData.sentryUrl
+      ? `[Sentry에서 보기](${sentryData.sentryUrl})`
+      : `Sentry URL을 찾을 수 없습니다.`,
   ].join("\n");
 
   const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
     method: "POST",
     headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
       "Content-Type": "application/json",
       Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
     },
     body: JSON.stringify({
-      title: `[Sentry] ${issue.title}`,
+      title: `[Sentry] ${sentryData.title}`,
       body: githubIssueBody,
       labels: ["bug", "sentry"],
     }),
@@ -56,9 +130,11 @@ export async function POST(request: NextRequest) {
 
   if (!response.ok) {
     const error = await response.text();
+
     return NextResponse.json({ error }, { status: response.status });
   }
 
   const githubIssue = await response.json();
+
   return NextResponse.json({ url: githubIssue.html_url }, { status: 201 });
-}
+};


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- Sentry Webhook payload 처리 로직을 수정했습니다.
- 기존에는 `payload.data.issue`가 있는 경우만 처리하고 있어, `event_alert.triggered` 이벤트에서는 `issue` 데이터를 찾지 못하고 400 에러가 발생했습니다.
- `issue` 데이터가 없는 경우에도 `event` 데이터를 기반으로 GitHub Issue를 생성할 수 있도록 수정했습니다.

## 참고 사항

- Sentry Alert Rule에서 발생하는 `event_alert.triggered` 이벤트도 처리할 수 있도록 수정했습니다.
- 기존 Sentry Issue 생성 이벤트 처리 흐름은 유지했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거