### PR TITLE
CI 환경에서 E2E 테스트 동작 시 Sentry 실행 제한

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build Next.js app
         run: npm run build
+        env:
+          NEXT_PUBLIC_IS_E2E: "true"
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,5 +57,8 @@ export default defineConfig({
     command: process.env.CI ? "npm run start" : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_IS_E2E: "true",
+    },
   },
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,12 +6,13 @@
 import * as Sentry from "@sentry/nextjs";
 
 const isProd = process.env.NODE_ENV === "production";
+const isE2E = process.env.NEXT_PUBLIC_IS_E2E === "true";
 
 Sentry.init({
   dsn: "https://733ec55f58e2fda3ed51d8127bda3036@o4510692801249280.ingest.us.sentry.io/4510692807475200",
 
-  // Conditionally disable locally
-  enabled: isProd,
+  // Conditionally disable locally and during E2E tests
+  enabled: isProd && !isE2E,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,12 +5,13 @@
 import * as Sentry from "@sentry/nextjs";
 
 const isProd = process.env.NODE_ENV === "production";
+const isE2E = process.env.NEXT_PUBLIC_IS_E2E === "true";
 
 Sentry.init({
   dsn: "https://733ec55f58e2fda3ed51d8127bda3036@o4510692801249280.ingest.us.sentry.io/4510692807475200",
 
-  // Conditionally disable locally
-  enabled: isProd,
+  // Conditionally disable locally and during E2E tests
+  enabled: isProd && !isE2E,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,12 +5,13 @@
 import * as Sentry from "@sentry/nextjs";
 
 const isProd = process.env.NODE_ENV === "production";
+const isE2E = process.env.NEXT_PUBLIC_IS_E2E === "true";
 
 Sentry.init({
   dsn: "https://733ec55f58e2fda3ed51d8127bda3036@o4510692801249280.ingest.us.sentry.io/4510692807475200",
 
-  // Conditionally disable locally
-  enabled: isProd,
+  // Conditionally disable locally and during E2E tests
+  enabled: isProd && !isE2E,
 
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- CI 테스트 실패 시 GitHub 이슈가 생성되는 문제가 있어, CI 환경에서는 Sentry가 실행되지 않도록 제한했습니다.

## 참고 사항

- CI 환경에서 발생하는 테스트 실패가 실제 운영 이슈로 등록되지 않도록 하기 위한 작업입니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거