### PR TITLE
브라우저 간 폰트 렌더링 차이 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,16 @@
 }
 
 @layer base {
+  body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-family:
+      var(--font-pretendard),
+      -apple-system,
+      BlinkMacSystemFont,
+      sans-serif;
+  }
+
   input:focus,
   textarea:focus,
   select:focus {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,8 @@ import TermsProvider from "@/providers/TermsProvider";
 const pretendard = localFont({
   src: "../../public/fonts/PretendardVariable.woff2",
   variable: "--font-pretendard",
+  display: "swap",
+  weight: "100 900",
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #1006
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- safari, chrome 등 각 브라우저 마다 폰트 렌더링이 다르게 되는 문제를 수정했습니다.
- layout.tsx
  - display: "swap"
  - 폰트 로딩 전까지 fallback 폰트를 보여주고, 로드 완료 시 교체됩니다.
  - 추가하지 않은 경우 브라우저마다 다른 기본 값을 사용해 폰트가 안 보이거나, 깜빡임 동작이 달라집니다.
  - weight: "100 900"
  - 폰트에 100~900 weight를 모두 지원한다고 명시했습니다.
  - 미설정 시 브라우저가 weight 범위를 추측해서 처리하면서, Safari와 Chrome이 서로 다른 방식으로 폴백처리를 하면서 굵기가 달라 보이는 원인이 됩니다.
- globals.css
  - -webkit-font-smoothing: antialiased
  - 폰트 렌더링 방식을 강제했습니다.
  - 같은 폰트인데도 다르게 굵기와 선명도가 다르게 보이는 문제를 수정했습니다.
  - -moz-osx-font-smoothing: grayscale
  - 파이어폭스 에서도 동일한 렌더링 방식을 적용했습니다.
  - font-family 명시
  - CSS 변수가 적용 안 되는 엣지 케이스를 방지하는 fallback 입니다.

## 참고 사항

- 브라우저마다 폰트 렌더링 방식이 동일하지 않기 때문에, 이번 작업으로 폰트 렌더링 차이를 개선했습니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
