### PR TITLE
메인/공지사항 e2e 테스트 작성

### DIFF
--- a/src/mock/data/index.ts
+++ b/src/mock/data/index.ts
@@ -1,4 +1,5 @@
 export * from "./chat.data";
+export * from "./main.data";
 export * from "./mypage.data";
 export * from "./posts.data";
 export * from "./userProfile.data";

--- a/src/mock/data/main.data.ts
+++ b/src/mock/data/main.data.ts
@@ -1,0 +1,44 @@
+export const MOCK_AUTH_REFRESH = {
+  isSuccess: true,
+  code: "200",
+  message: "OK",
+  result: { userId: 1, temporaryPassword: false },
+};
+
+export const MOCK_USERS_ME = {
+  isSuccess: true,
+  code: "200",
+  message: "OK",
+  result: { userId: 1, nickName: "테스트유저", profileImage: "", email: "test@test.com" },
+};
+
+export const MOCK_KAKAO_COORD2ADDRESS = {
+  documents: [
+    {
+      address: {
+        address_name: "서울특별시 중구 명동2가 1",
+        region_2depth_name: "중구",
+        region_3depth_name: "명동2가",
+      },
+      road_address: {
+        address_name: "서울특별시 중구 명동길 14",
+        region_3depth_name: "명동",
+      },
+    },
+  ],
+  meta: { total_count: 1 },
+};
+
+export const MOCK_MARKER = {
+  isSuccess: true,
+  code: "200",
+  message: "OK",
+  result: [],
+};
+
+export const MOCK_RECENT_FOUND_EMPTY = {
+  isSuccess: true,
+  code: "200",
+  message: "OK",
+  result: [],
+};

--- a/tests/e2e/main.spec.ts
+++ b/tests/e2e/main.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+  MOCK_AUTH_REFRESH,
+  MOCK_KAKAO_COORD2ADDRESS,
+  MOCK_MARKER,
+  MOCK_RECENT_FOUND_EMPTY,
+  MOCK_USERS_ME,
+} from "@/mock/data/main.data";
+
+async function setupMainPageMocks(page: Page) {
+  await page.route("**/api/auth/refresh", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_AUTH_REFRESH),
+    })
+  );
+
+  await page.route("**/api/users/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_USERS_ME),
+    })
+  );
+
+  await page.route("https://dapi.kakao.com/v2/local/geo/coord2address.json**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_KAKAO_COORD2ADDRESS),
+    })
+  );
+
+  await page.route("https://dapi.kakao.com/v2/maps/**", (route) => route.abort());
+
+  await page.route("**/api/main/posts/marker**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_MARKER),
+    })
+  );
+
+  await page.route("**/api/main/posts/recent-found**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_RECENT_FOUND_EMPTY),
+    })
+  );
+}
+
+test.describe("메인 페이지", () => {
+  test("헤더·바텀시트 기본 UI가 보인다", async ({ page }) => {
+    await setupMainPageMocks(page);
+    await page.goto("/");
+
+    await expect(page.getByPlaceholder("현재 위치 (위치 정보 허용 시)")).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "분실 신고 목록 페이지로 이동" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "발견 신고 목록 페이지로 이동" })).toBeVisible();
+
+    await expect(page.getByText("아직 발견된 분실물이 없어요")).toBeVisible({ timeout: 15000 });
+
+    await expect(page.getByRole("button", { name: "바텀시트 높이 조절" })).toBeVisible();
+  });
+
+  test("분실 신고 카드 클릭 시 분실 목록으로 이동한다", async ({ page }) => {
+    await setupMainPageMocks(page);
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "분실 신고 목록 페이지로 이동" }).click();
+
+    await page.waitForURL("**/list?type=lost");
+    await expect(page).toHaveURL(/\/list\?type=lost/);
+  });
+
+  test("발견 신고 카드 클릭 시 발견 목록으로 이동한다", async ({ page }) => {
+    await setupMainPageMocks(page);
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "발견 신고 목록 페이지로 이동" }).click();
+
+    await page.waitForURL("**/list?type=found");
+    await expect(page).toHaveURL(/\/list\?type=found/);
+  });
+
+  test("검색어 제출 시 메인에 검색 쿼리가 반영된다", async ({ page }) => {
+    await setupMainPageMocks(page);
+    await page.goto("/");
+
+    const keyword = "테스트키워드";
+    const searchInput = page.getByPlaceholder("현재 위치 (위치 정보 허용 시)");
+    await searchInput.fill(keyword);
+    await searchInput.press("Enter");
+
+    await page.waitForURL(`**/?search=${encodeURIComponent(keyword)}`);
+    await expect(page).toHaveURL(new RegExp(`[?&]search=${encodeURIComponent(keyword)}`));
+  });
+});

--- a/tests/e2e/main.spec.ts
+++ b/tests/e2e/main.spec.ts
@@ -52,50 +52,42 @@ async function setupMainPageMocks(page: Page) {
 }
 
 test.describe("메인 페이지", () => {
-  test("헤더·바텀시트 기본 UI가 보인다", async ({ page }) => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
     await setupMainPageMocks(page);
     await page.goto("/");
+  });
 
+  test("헤더·바텀시트 기본 UI가 보인다", async ({ page }) => {
     await expect(page.getByPlaceholder("현재 위치 (위치 정보 허용 시)")).toBeVisible();
 
     await expect(page.getByRole("link", { name: "분실 신고 목록 페이지로 이동" })).toBeVisible();
     await expect(page.getByRole("link", { name: "발견 신고 목록 페이지로 이동" })).toBeVisible();
 
-    await expect(page.getByText("아직 발견된 분실물이 없어요")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText("아직 발견된 분실물이 없어요")).toBeVisible();
 
     await expect(page.getByRole("button", { name: "바텀시트 높이 조절" })).toBeVisible();
   });
 
   test("분실 신고 카드 클릭 시 분실 목록으로 이동한다", async ({ page }) => {
-    await setupMainPageMocks(page);
-    await page.goto("/");
-
     await page.getByRole("link", { name: "분실 신고 목록 페이지로 이동" }).click();
 
-    await page.waitForURL("**/list?type=lost");
     await expect(page).toHaveURL(/\/list\?type=lost/);
   });
 
   test("발견 신고 카드 클릭 시 발견 목록으로 이동한다", async ({ page }) => {
-    await setupMainPageMocks(page);
-    await page.goto("/");
-
     await page.getByRole("link", { name: "발견 신고 목록 페이지로 이동" }).click();
 
-    await page.waitForURL("**/list?type=found");
     await expect(page).toHaveURL(/\/list\?type=found/);
   });
 
   test("검색어 제출 시 메인에 검색 쿼리가 반영된다", async ({ page }) => {
-    await setupMainPageMocks(page);
-    await page.goto("/");
-
     const keyword = "테스트키워드";
     const searchInput = page.getByPlaceholder("현재 위치 (위치 정보 허용 시)");
     await searchInput.fill(keyword);
     await searchInput.press("Enter");
 
-    await page.waitForURL(`**/?search=${encodeURIComponent(keyword)}`);
     await expect(page).toHaveURL(new RegExp(`[?&]search=${encodeURIComponent(keyword)}`));
   });
 });

--- a/tests/e2e/notice.spec.ts
+++ b/tests/e2e/notice.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+  MOCK_NOTICE_COMMENTS_EMPTY_FIRST_PAGE,
+  MOCK_NOTICES_RESPONSE,
+  MOCK_USERS_ME_NOTICE_HEADER_ADMIN,
+  MOCK_USERS_ME_NOTICE_HEADER_USER,
+  createMockNoticeDetailHeaderResponse,
+} from "@/mock/data/notice.data";
+
+async function setupNoticeMocks(page: Page, usersMe: typeof MOCK_USERS_ME_NOTICE_HEADER_USER) {
+  await page.route("**/api/users/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(usersMe),
+    })
+  );
+
+  await page.route("**/api/notices**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (/^\/api\/notices\/\d+\/comments/.test(path)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_NOTICE_COMMENTS_EMPTY_FIRST_PAGE),
+      });
+      return;
+    }
+
+    const detailMatch = path.match(/^\/api\/notices\/(\d+)$/);
+    if (detailMatch) {
+      const id = Number(detailMatch[1]);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(createMockNoticeDetailHeaderResponse(id)),
+      });
+      return;
+    }
+
+    if (path === "/api/notices") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_NOTICES_RESPONSE),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+test.describe("공지사항 목록", () => {
+  test("헤더·검색·목록이 보인다", async ({ page }) => {
+    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
+    await page.goto("/notice");
+
+    await expect(page.getByRole("heading", { name: "공지사항", level: 2 })).toBeVisible();
+    await expect(page.locator("h1.sr-only", { hasText: "공지사항 페이지" })).toBeAttached();
+
+    await expect(page.getByPlaceholder("제목, 내용을 입력해 주세요.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "공지사항 정렬 필터" })).toBeVisible();
+
+    await expect(page.getByText("서비스 점검 안내")).toBeVisible();
+    await expect(page.getByText("이벤트: 분실물 찾기 캠페인")).toBeVisible();
+  });
+
+  test("공지 클릭 시 상세 페이지로 이동하고 제목이 보인다", async ({ page }) => {
+    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
+    await page.goto("/notice");
+
+    await page.getByRole("link", { name: /서비스 점검 안내/ }).click();
+
+    await page.waitForURL("**/notice/1");
+    await expect(page.getByRole("heading", { name: "서비스 점검 안내" })).toBeVisible();
+  });
+
+  test("검색어 제출 시 keyword 쿼리가 반영된다", async ({ page }) => {
+    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
+    await page.goto("/notice");
+
+    const keyword = "e2e검색";
+    await page.getByPlaceholder("제목, 내용을 입력해 주세요.").fill(keyword);
+    await page.getByPlaceholder("제목, 내용을 입력해 주세요.").press("Enter");
+
+    await page.waitForURL(`**/notice?keyword=${encodeURIComponent(keyword)}`);
+    await expect(page).toHaveURL(new RegExp(`[?&]keyword=${encodeURIComponent(keyword)}`));
+  });
+
+  test('정렬에서 "조회 많은 순" 선택 시 sortType이 반영된다', async ({ page }) => {
+    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
+    await page.goto("/notice");
+
+    await page.getByRole("button", { name: "공지사항 정렬 필터" }).click();
+    await page.getByRole("button", { name: "조회 많은 순" }).click();
+
+    await page.waitForURL("**/notice?sortType=most_viewed");
+    await expect(page).toHaveURL(/sortType=most_viewed/);
+  });
+
+  test("관리자일 때 공지 작성 플로팅 버튼이 보인다", async ({ page }) => {
+    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_ADMIN);
+    await page.goto("/notice");
+
+    await expect(page.getByRole("button", { name: "공지사항 작성 페이지 이동" })).toBeVisible();
+  });
+});

--- a/tests/e2e/notice.spec.ts
+++ b/tests/e2e/notice.spec.ts
@@ -54,57 +54,56 @@ async function setupNoticeMocks(page: Page, usersMe: typeof MOCK_USERS_ME_NOTICE
 }
 
 test.describe("공지사항 목록", () => {
-  test("헤더·검색·목록이 보인다", async ({ page }) => {
-    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
-    await page.goto("/notice");
+  test.describe.configure({ mode: "serial" });
 
-    await expect(page.getByRole("heading", { name: "공지사항", level: 2 })).toBeVisible();
-    await expect(page.locator("h1.sr-only", { hasText: "공지사항 페이지" })).toBeAttached();
+  test.describe("일반 사용자", () => {
+    test.beforeEach(async ({ page }) => {
+      await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
+      await page.goto("/notice");
+    });
 
-    await expect(page.getByPlaceholder("제목, 내용을 입력해 주세요.")).toBeVisible();
-    await expect(page.getByRole("button", { name: "공지사항 정렬 필터" })).toBeVisible();
+    test("헤더·검색·목록이 보인다", async ({ page }) => {
+      await expect(page.getByRole("heading", { name: "공지사항", level: 2 })).toBeVisible();
+      await expect(page.locator("h1.sr-only", { hasText: "공지사항 페이지" })).toBeAttached();
 
-    await expect(page.getByText("서비스 점검 안내")).toBeVisible();
-    await expect(page.getByText("이벤트: 분실물 찾기 캠페인")).toBeVisible();
+      await expect(page.getByPlaceholder("제목, 내용을 입력해 주세요.")).toBeVisible();
+      await expect(page.getByRole("button", { name: "공지사항 정렬 필터" })).toBeVisible();
+
+      await expect(page.getByText("서비스 점검 안내")).toBeVisible();
+      await expect(page.getByText("이벤트: 분실물 찾기 캠페인")).toBeVisible();
+    });
+
+    test("공지 클릭 시 상세 페이지로 이동하고 제목이 보인다", async ({ page }) => {
+      await page.getByRole("link", { name: /서비스 점검 안내/ }).click();
+
+      await expect(page).toHaveURL(/\/notice\/1$/);
+      await expect(page.getByRole("heading", { name: "서비스 점검 안내" })).toBeVisible();
+    });
+
+    test("검색어 제출 시 keyword 쿼리가 반영된다", async ({ page }) => {
+      const keyword = "e2e검색";
+      await page.getByPlaceholder("제목, 내용을 입력해 주세요.").fill(keyword);
+      await page.getByPlaceholder("제목, 내용을 입력해 주세요.").press("Enter");
+
+      await expect(page).toHaveURL(new RegExp(`[?&]keyword=${encodeURIComponent(keyword)}`));
+    });
+
+    test('정렬에서 "조회 많은 순" 선택 시 sortType이 반영된다', async ({ page }) => {
+      await page.getByRole("button", { name: "공지사항 정렬 필터" }).click();
+      await page.getByRole("button", { name: "조회 많은 순" }).click();
+
+      await expect(page).toHaveURL(/sortType=most_viewed/);
+    });
   });
 
-  test("공지 클릭 시 상세 페이지로 이동하고 제목이 보인다", async ({ page }) => {
-    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
-    await page.goto("/notice");
+  test.describe("관리자", () => {
+    test.beforeEach(async ({ page }) => {
+      await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_ADMIN);
+      await page.goto("/notice");
+    });
 
-    await page.getByRole("link", { name: /서비스 점검 안내/ }).click();
-
-    await page.waitForURL("**/notice/1");
-    await expect(page.getByRole("heading", { name: "서비스 점검 안내" })).toBeVisible();
-  });
-
-  test("검색어 제출 시 keyword 쿼리가 반영된다", async ({ page }) => {
-    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
-    await page.goto("/notice");
-
-    const keyword = "e2e검색";
-    await page.getByPlaceholder("제목, 내용을 입력해 주세요.").fill(keyword);
-    await page.getByPlaceholder("제목, 내용을 입력해 주세요.").press("Enter");
-
-    await page.waitForURL(`**/notice?keyword=${encodeURIComponent(keyword)}`);
-    await expect(page).toHaveURL(new RegExp(`[?&]keyword=${encodeURIComponent(keyword)}`));
-  });
-
-  test('정렬에서 "조회 많은 순" 선택 시 sortType이 반영된다', async ({ page }) => {
-    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_USER);
-    await page.goto("/notice");
-
-    await page.getByRole("button", { name: "공지사항 정렬 필터" }).click();
-    await page.getByRole("button", { name: "조회 많은 순" }).click();
-
-    await page.waitForURL("**/notice?sortType=most_viewed");
-    await expect(page).toHaveURL(/sortType=most_viewed/);
-  });
-
-  test("관리자일 때 공지 작성 플로팅 버튼이 보인다", async ({ page }) => {
-    await setupNoticeMocks(page, MOCK_USERS_ME_NOTICE_HEADER_ADMIN);
-    await page.goto("/notice");
-
-    await expect(page.getByRole("button", { name: "공지사항 작성 페이지 이동" })).toBeVisible();
+    test("관리자일 때 공지 작성 플로팅 버튼이 보인다", async ({ page }) => {
+      await expect(page.getByRole("button", { name: "공지사항 작성 페이지 이동" })).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- #960
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 메인/공지사항 페이지에 대한 e2e 테스트를 작성했습니다.
- 메인: 헤더/바텀시트 UI, 분실 신고 이동, 발견 신고 이동, 메인 검색
- 공지사항: 목록 기본 UI, 목록 상세, 공지 검색, 정렬

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
