### PR TITLE
채팅 탈퇴 케이스 구현

### DIFF
--- a/src/api/fetch/chatRoom/types/ChatRoomResponse.ts
+++ b/src/api/fetch/chatRoom/types/ChatRoomResponse.ts
@@ -19,6 +19,7 @@ export interface ChatRoom {
     userId: number;
     nickname: string;
     profileImageUrl: string | null;
+    withdrawn: boolean;
   };
   postInfo: ChatRoomPostInfo;
   messageType: MessageType | null;
@@ -58,6 +59,7 @@ export interface ChatRoomResponse {
     nickname: string;
     profileImageUrl: string;
     emailVerified: boolean;
+    withdrawn: boolean;
   };
   postInfo: ChatRoomPostInfo;
 }

--- a/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.stories.tsx
+++ b/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.stories.tsx
@@ -51,12 +51,25 @@ type Story = StoryObj<typeof ChatRoomHeader>;
 export const Found: Story = {
   args: {
     chatRoom: MOCK_CHAT_ROOM_FOUND,
+    roomId: MOCK_CHAT_ROOM_FOUND.roomId,
+    withdrawn: false,
   },
 };
 
 export const Lost: Story = {
   args: {
     chatRoom: MOCK_CHAT_ROOM_LOST,
+    roomId: MOCK_CHAT_ROOM_LOST.roomId,
+    withdrawn: false,
+  },
+};
+
+export const OpponentWithdrawn: Story = {
+  args: {
+    chatRoom: MOCK_CHAT_ROOM_FOUND,
+    roomId: MOCK_CHAT_ROOM_FOUND.roomId,
+    withdrawn: true,
+    currentUserId: 999,
   },
 };
 
@@ -69,11 +82,15 @@ export const WithoutThumbnail: Story = {
         thumbnailUrl: "",
       },
     },
+    roomId: MOCK_CHAT_ROOM_FOUND.roomId,
+    withdrawn: false,
   },
 };
 
 export const Undefined: Story = {
   args: {
     chatRoom: undefined,
+    roomId: 0,
+    withdrawn: false,
   },
 };

--- a/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.test.tsx
+++ b/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.test.tsx
@@ -30,14 +30,30 @@ jest.mock("../ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton", () => ({
   default: () => <div data-testid="chat-room-header-info-button">InfoButton</div>,
 }));
 
+const renderChatRoomHeader = (
+  overrides: Partial<React.ComponentProps<typeof ChatRoomHeader>> = {}
+) =>
+  render(
+    <ChatRoomHeader
+      chatRoom={MOCK_CHAT_ROOM_FOUND}
+      roomId={MOCK_CHAT_ROOM_FOUND.roomId}
+      withdrawn={false}
+      {...overrides}
+    />
+  );
+
 describe("ChatRoomHeader", () => {
   it("chatRoom이 undefined일 때 null을 반환합니다", () => {
-    const { container } = render(<ChatRoomHeader chatRoom={undefined} roomId={0} />);
+    const { container } = renderChatRoomHeader({
+      chatRoom: undefined,
+      roomId: 0,
+      withdrawn: false,
+    });
     expect(container.firstChild).toBeNull();
   });
 
   it("뒤로가기 링크가 렌더링되고 /chat 경로를 가집니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     const backLink = screen.getByRole("link", { name: "뒤로 가기 버튼" });
     expect(backLink).toBeInTheDocument();
@@ -46,13 +62,13 @@ describe("ChatRoomHeader", () => {
   });
 
   it("사용자 닉네임이 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     expect(screen.getByText("사용자 닉네임")).toBeInTheDocument();
   });
 
   it("게시글 썸네일 이미지가 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     const image = screen.getByAltText("채팅방 게시글 썸네일");
     expect(image).toBeInTheDocument();
@@ -60,7 +76,7 @@ describe("ChatRoomHeader", () => {
   });
 
   it("ChatChip이 postType과 함께 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     const chatChip = screen.getByTestId("chat-chip");
     expect(chatChip).toBeInTheDocument();
@@ -68,14 +84,14 @@ describe("ChatRoomHeader", () => {
   });
 
   it("postType이 LOST일 때 ChatChip에 LOST가 전달됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_LOST} roomId={MOCK_CHAT_ROOM_LOST.roomId} />);
+    renderChatRoomHeader({ chatRoom: MOCK_CHAT_ROOM_LOST, roomId: MOCK_CHAT_ROOM_LOST.roomId });
 
     const chatChip = screen.getByTestId("chat-chip");
     expect(chatChip).toHaveTextContent("LOST");
   });
 
   it("게시글명이 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     expect(
       screen.getByText("여기에 게시글명이 표기됩니다 여기에 게시글명이 표기됩니다. 여기에")
@@ -83,19 +99,19 @@ describe("ChatRoomHeader", () => {
   });
 
   it("위치 정보가 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     expect(screen.getByText("서울시 중구 회현동")).toBeInTheDocument();
   });
 
   it("ChatRoomHeaderInfoButton이 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     expect(screen.getByTestId("chat-room-header-info-button")).toBeInTheDocument();
   });
 
   it("게시글 링크가 올바른 href를 가집니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     const link = screen.getByRole("link", { name: "게시글 상세 페이지 이동" });
     expect(link).toHaveAttribute("href", `/list/${MOCK_CHAT_ROOM_FOUND.postInfo.postId}`);
@@ -111,19 +127,17 @@ describe("ChatRoomHeader", () => {
       },
     };
 
-    render(
-      <ChatRoomHeader
-        chatRoom={chatRoomWithoutThumbnail}
-        roomId={chatRoomWithoutThumbnail.roomId}
-      />
-    );
+    renderChatRoomHeader({
+      chatRoom: chatRoomWithoutThumbnail,
+      roomId: chatRoomWithoutThumbnail.roomId,
+    });
 
     const image = screen.getByAltText("채팅방 게시글 썸네일");
     expect(image).toBeInTheDocument();
   });
 
   it("모든 주요 요소가 함께 렌더링됩니다", () => {
-    render(<ChatRoomHeader chatRoom={MOCK_CHAT_ROOM_FOUND} roomId={MOCK_CHAT_ROOM_FOUND.roomId} />);
+    renderChatRoomHeader();
 
     // 뒤로가기 링크
     expect(screen.getByRole("link", { name: "뒤로 가기 버튼" })).toBeInTheDocument();
@@ -148,5 +162,24 @@ describe("ChatRoomHeader", () => {
 
     // 위치 정보
     expect(screen.getByText("서울시 중구 회현동")).toBeInTheDocument();
+  });
+
+  it("withdrawn이 true이면 닉네임 대신 탈퇴 문구를 표시한다", () => {
+    renderChatRoomHeader({
+      withdrawn: true,
+      currentUserId: 999,
+    });
+
+    expect(screen.getByText("탈퇴한 회원이에요")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "상대방 프로필 이동" })).not.toBeInTheDocument();
+  });
+
+  it("withdrawn이 true이고 내 게시글 채팅이면 상대 닉네임 대신 탈퇴 문구를 표시한다", () => {
+    renderChatRoomHeader({
+      withdrawn: true,
+      currentUserId: MOCK_CHAT_ROOM_FOUND.opponentUser.opponentUserId,
+    });
+
+    expect(screen.getByText("탈퇴한 회원이에요")).toBeInTheDocument();
   });
 });

--- a/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
+++ b/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
@@ -17,6 +17,7 @@ interface ChatRoomHeaderProps {
   chatRoom: ChatRoomResponse | undefined;
   roomId: number;
   currentUserId?: number;
+  withdrawn: boolean;
 }
 
 const LinkWrapper = ({ deleted, children, href }: LinkWrapperProps) => {
@@ -39,7 +40,7 @@ const LinkWrapper = ({ deleted, children, href }: LinkWrapperProps) => {
 
 const NICK_NAME_STYLE = "text-body2-semibold text-layout-body-default";
 
-const ChatRoomHeader = ({ chatRoom, roomId, currentUserId }: ChatRoomHeaderProps) => {
+const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoomHeaderProps) => {
   if (!chatRoom) return null;
   const { address, postType, title, thumbnailUrl, postId, category, postStatus, deleted } =
     chatRoom.postInfo;
@@ -58,8 +59,8 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId }: ChatRoomHeaderProps
           <Icon name="ArrowLeftSmall" size={18} className="text-neutral-normal-default" />
         </Link>
 
-        {isOwnPostChatRoom ? (
-          <p className={NICK_NAME_STYLE}>{nickname}</p>
+        {isOwnPostChatRoom || withdrawn ? (
+          <p className={NICK_NAME_STYLE}>{withdrawn ? "탈퇴한 회원이에요" : nickname}</p>
         ) : (
           <Link
             href={`/user/${opponentUserId}`}
@@ -87,7 +88,7 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId }: ChatRoomHeaderProps
           <div className="flex items-center gap-1">
             <ChatChip postMode={postType} postStatus={postStatus} />
             <h2 className="truncate text-body1-semibold text-layout-header-default">
-              {deleted ? `삭제됨 ${title}` : title}
+              {deleted === !withdrawn ? `삭제됨 ${title}` : title}
             </h2>
           </div>
           <p className="min-h-4 text-caption1-medium text-layout-body-default">{address}</p>

--- a/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
+++ b/src/app/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
@@ -88,7 +88,7 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoom
           <div className="flex items-center gap-1">
             <ChatChip postMode={postType} postStatus={postStatus} />
             <h2 className="truncate text-body1-semibold text-layout-header-default">
-              {deleted === !withdrawn ? `삭제됨 ${title}` : title}
+              {deleted && !withdrawn ? `삭제됨 ${title}` : title}
             </h2>
           </div>
           <p className="min-h-4 text-caption1-medium text-layout-body-default">{address}</p>

--- a/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.test.tsx
+++ b/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.test.tsx
@@ -25,6 +25,7 @@ const renderComponent = (props: Partial<React.ComponentProps<typeof InputChat>> 
     name: "test-chat",
     roomId: 1,
     userId: 1,
+    withdrawn: false,
   };
   const mergedProps = { ...defaultProps, ...props };
 
@@ -105,6 +106,16 @@ describe("InputChat 컴포넌트", () => {
 
   it("disabled prop이 true일 때 전송 버튼이 비활성화되는지 확인", () => {
     renderComponent({ disabled: true });
+
+    const sendButton = screen.getByLabelText("전송 버튼");
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("withdrawn이 true이면 입력창·전송이 비활성화되고 탈퇴 안내 placeholder를 쓴다", () => {
+    renderComponent({ withdrawn: true });
+
+    const input = screen.getByPlaceholderText("상대방이 탈퇴한 회원입니다.");
+    expect(input).toBeDisabled();
 
     const sendButton = screen.getByLabelText("전송 버튼");
     expect(sendButton).toBeDisabled();

--- a/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
+++ b/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
@@ -70,6 +70,7 @@ const InputChat = ({
                 )}
                 aria-label="이미지 첨부"
                 role="button"
+                aria-disabled={withdrawn}
               >
                 <Icon
                   name="Image"

--- a/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
+++ b/src/app/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
@@ -14,6 +14,7 @@ interface InputChatProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   roomId: number;
   userId: number;
   onImageSendSuccess?: () => void;
+  withdrawn: boolean;
 }
 
 const InputChat = ({
@@ -23,6 +24,7 @@ const InputChat = ({
   roomId,
   userId,
   onImageSendSuccess,
+  withdrawn,
   ...props
 }: InputChatProps) => {
   const { control, watch } = useFormContext();
@@ -62,7 +64,10 @@ const InputChat = ({
               {/* 이미지 첨부 */}
               <label
                 htmlFor="ImageAttach"
-                className="relative h-11 w-11 shrink-0 rounded-full bg-fill-neutral-strong-default"
+                className={cn(
+                  "relative h-11 w-11 shrink-0 rounded-full bg-fill-neutral-strong-default",
+                  withdrawn && "cursor-default"
+                )}
                 aria-label="이미지 첨부"
                 role="button"
               >
@@ -78,7 +83,7 @@ const InputChat = ({
                 accept="image/*"
                 multiple
                 className="hidden"
-                disabled={disabled}
+                disabled={disabled || withdrawn}
                 onChange={(e) => fileInputHandler(e, images, setImages)}
               />
 
@@ -100,8 +105,8 @@ const InputChat = ({
                   "max-h-[120px] min-h-11 min-w-0 flex-1 resize-none overflow-y-hidden rounded-[24px] px-4 py-[10px] text-body1-medium text-neutral-normal-placeholder bg-fill-neutral-strong-default focus:text-black disabled:text-neutral-strong-disabled",
                   field.value && "text-neutral-strong-focused"
                 )}
-                placeholder="메시지 보내기"
-                disabled={disabled}
+                placeholder={withdrawn ? "상대방이 탈퇴한 회원입니다." : "메시지 보내기"}
+                disabled={disabled || withdrawn}
                 maxLength={255}
               />
 

--- a/src/app/(route)/chat/[postId]/_hooks/useChatRoomData/useChatRoomData.test.tsx
+++ b/src/app/(route)/chat/[postId]/_hooks/useChatRoomData/useChatRoomData.test.tsx
@@ -30,6 +30,7 @@ const makeChatRoomResult = (overrides: Partial<ChatRoomResponse> = {}): ChatRoom
     nickname: "상대",
     profileImageUrl: "",
     emailVerified: true,
+    withdrawn: false,
   },
   postInfo: {
     postId: 99,
@@ -155,5 +156,25 @@ describe("useChatRoomData", () => {
     expect(result.current.roomId).toBe(0);
     expect(result.current.chatRoomData).toBeUndefined();
     expect(result.current.unreadCount).toBeUndefined();
+  });
+
+  it("opponentUser.withdrawn이 true이면 withdrawn이 true다", () => {
+    mockUseSearchParams.mockReturnValue({
+      get: jest.fn(() => null),
+    });
+    const room = makeChatRoomResult({
+      opponentUser: {
+        ...makeChatRoomResult().opponentUser,
+        withdrawn: true,
+      },
+    });
+    mockUseChatRoom.mockReturnValue({
+      data: { result: room },
+    } as ReturnType<typeof useChatRoom>);
+    mockUseGetChatRoom.mockReturnValue({ data: undefined } as ReturnType<typeof useGetChatRoom>);
+
+    const { result } = renderHook(() => useChatRoomData(1), { wrapper });
+
+    expect(result.current.withdrawn).toBe(true);
   });
 });

--- a/src/app/(route)/chat/[postId]/_hooks/useChatRoomData/useChatRoomData.ts
+++ b/src/app/(route)/chat/[postId]/_hooks/useChatRoomData/useChatRoomData.ts
@@ -25,6 +25,7 @@ const useChatRoomData = (postId: number) => {
     userInfo,
     postMode,
     unreadCount,
+    withdrawn: chatRoomData?.opponentUser.withdrawn || false,
   };
 };
 

--- a/src/app/(route)/chat/[postId]/page.tsx
+++ b/src/app/(route)/chat/[postId]/page.tsx
@@ -35,7 +35,7 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
     if (withdrawn) {
       addToast("알 수 없는 사용자이거나 탈퇴한 회원이에요", "warning");
     }
-  }, [withdrawn]);
+  }, [withdrawn, addToast]);
 
   useChatSocketMessage(roomId, currentUserId);
 

--- a/src/app/(route)/chat/[postId]/page.tsx
+++ b/src/app/(route)/chat/[postId]/page.tsx
@@ -11,6 +11,7 @@ import {
   useChatMessageSubmit,
 } from "./_hooks";
 import useReadMessage from "@/api/fetch/chatMessage/api/useReadMessage";
+import { useToast } from "@/context/ToastContext";
 
 interface ChatFormValues {
   content: string;
@@ -18,15 +19,23 @@ interface ChatFormValues {
 
 const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
   const { postId: postIdString } = use(params);
+  const { addToast } = useToast();
   const postId = Number(postIdString);
 
-  const { roomId, chatRoomData, userInfo, postMode, unreadCount } = useChatRoomData(postId);
+  const { roomId, chatRoomData, userInfo, postMode, unreadCount, withdrawn } =
+    useChatRoomData(postId);
   const userId = Number(userInfo?.result?.userId);
   const currentUserId = userId != null ? userId : undefined;
   const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0);
   const triggerScrollToBottom = useCallback(() => {
     setScrollToBottomSignal((prev) => prev + 1);
   }, []);
+
+  useEffect(() => {
+    if (withdrawn) {
+      addToast("알 수 없는 사용자이거나 탈퇴한 회원이에요", "warning");
+    }
+  }, [withdrawn]);
 
   useChatSocketMessage(roomId, currentUserId);
 

--- a/src/app/(route)/chat/[postId]/page.tsx
+++ b/src/app/(route)/chat/[postId]/page.tsx
@@ -77,7 +77,12 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
-      <ChatRoomHeader chatRoom={chatRoomData} roomId={roomId} currentUserId={currentUserId} />
+      <ChatRoomHeader
+        chatRoom={chatRoomData}
+        roomId={roomId}
+        currentUserId={currentUserId}
+        withdrawn={withdrawn}
+      />
       <h1 className="sr-only">채팅 상세 페이지</h1>
 
       <div className="flex min-h-0 flex-1 flex-col">
@@ -103,6 +108,7 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
               roomId={roomId}
               userId={userId}
               onImageSendSuccess={triggerScrollToBottom}
+              withdrawn={withdrawn}
             />
           </form>
         </FormProvider>

--- a/src/app/(route)/chat/_components/ChatItem/ChatItem.test.tsx
+++ b/src/app/(route)/chat/_components/ChatItem/ChatItem.test.tsx
@@ -72,6 +72,7 @@ describe("ChatItem", () => {
         userId: 1,
         nickname: "사용자 닉네임",
         profileImageUrl: "profile.jpg",
+        withdrawn: false,
       },
     });
 
@@ -115,6 +116,16 @@ describe("ChatItem", () => {
     render(<ChatItem chatRoom={chatRoomNoUnread} />);
 
     expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("withdrawn이 true이면 닉네임 대신 탈퇴한 회원을 표시한다", () => {
+    const withdrawnRoom = createMockChatRoom({
+      contactUser: { ...MOCK_CHAT_ITEM.contactUser, nickname: "이전닉네임", withdrawn: true },
+    });
+    render(<ChatItem chatRoom={withdrawnRoom} />);
+
+    expect(screen.getByText("탈퇴한 회원")).toBeInTheDocument();
+    expect(screen.queryByText("이전닉네임")).not.toBeInTheDocument();
   });
 
   it("모든 주요 요소가 함께 렌더링됩니다", () => {

--- a/src/app/(route)/chat/_components/ChatItem/ChatItem.tsx
+++ b/src/app/(route)/chat/_components/ChatItem/ChatItem.tsx
@@ -10,7 +10,7 @@ interface ChatItemProps {
 const ChatItem = ({ chatRoom }: ChatItemProps) => {
   const { lastMessageSentAt, lastMessage, unreadCount, messageType } = chatRoom;
   const { postId, address, thumbnailUrl, category } = chatRoom.postInfo;
-  const { nickname, profileImageUrl } = chatRoom.contactUser;
+  const { nickname, profileImageUrl, withdrawn } = chatRoom.contactUser;
   const { roomId } = chatRoom;
 
   const lastMessageIsImage = lastMessageSentAt && messageType === "IMAGE";
@@ -41,7 +41,7 @@ const ChatItem = ({ chatRoom }: ChatItemProps) => {
       <div className="w-full min-w-0 space-y-[2px]">
         <div className="flex items-center justify-between truncate">
           <span className="truncate text-h3-semibold text-layout-header-default">
-            {nickname || "닉네임을 불러오지 못했습니다."}
+            {withdrawn ? "탈퇴한 회원" : nickname || "닉네임을 불러오지 못했습니다."}
           </span>
           {unreadCount > 0 && (
             <span className="rounded-full bg-flatGreen-500 px-[5.5px] py-[1.5px] text-caption2-semibold text-white flex-center">

--- a/src/app/(route)/chat/_components/DefaultChatList/DefaultChatList.test.tsx
+++ b/src/app/(route)/chat/_components/DefaultChatList/DefaultChatList.test.tsx
@@ -56,7 +56,12 @@ jest.mock("@/api/fetch/chatRoom", () => {
       data: Array.from({ length: 5 }, (_, i) => ({
         ...MOCK_CHAT_ITEM,
         roomId: i + 1,
-        contactUser: { userId: i + 1, nickname: `User${i + 1}`, profileImageUrl: null },
+        contactUser: {
+          userId: i + 1,
+          nickname: `User${i + 1}`,
+          profileImageUrl: null,
+          withdrawn: false,
+        },
         postInfo: {
           postId: i + 1,
           postType: MOCK_POST_ITEM.postType,

--- a/src/mock/data/chat.data.ts
+++ b/src/mock/data/chat.data.ts
@@ -13,6 +13,7 @@ export const MOCK_CHAT_ITEM: ChatRoom = {
     userId: 1,
     nickname: "사용자 닉네임",
     profileImageUrl: null,
+    withdrawn: false,
   },
   postInfo: {
     postId: 1,
@@ -51,6 +52,22 @@ export const MOCK_CHAT_LIST_EMPTY_RESPONSE: ApiBaseResponseType<ChatListType> = 
   },
 };
 
+/** 채팅 목록에서 상대가 탈퇴한 케이스 */
+export const MOCK_CHAT_ITEM_WITHDRAWN: ChatRoom = {
+  ...MOCK_CHAT_ITEM,
+  contactUser: { ...MOCK_CHAT_ITEM.contactUser, withdrawn: true },
+};
+
+export const MOCK_CHAT_LIST_WITH_WITHDRAWN_RESPONSE: ApiBaseResponseType<ChatListType> = {
+  isSuccess: true,
+  code: "200",
+  message: "OK",
+  result: {
+    chatRooms: [MOCK_CHAT_ITEM_WITHDRAWN],
+    nextCursor: null,
+  },
+};
+
 export const MOCK_CHAT_ROOM_FOUND: ChatRoomResponse = {
   roomId: 1,
   unreadCount: 0,
@@ -59,6 +76,7 @@ export const MOCK_CHAT_ROOM_FOUND: ChatRoomResponse = {
     nickname: "사용자 닉네임",
     profileImageUrl: "https://via.placeholder.com/40",
     emailVerified: true,
+    withdrawn: false,
   },
   postInfo: {
     postId: 1,
@@ -80,6 +98,7 @@ export const MOCK_CHAT_ROOM_LOST: ChatRoomResponse = {
     nickname: "다른 사용자",
     profileImageUrl: "https://via.placeholder.com/40",
     emailVerified: true,
+    withdrawn: false,
   },
   postInfo: {
     postId: 2,

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -3,6 +3,7 @@ import {
   MOCK_CHAT_LIST_EMPTY_RESPONSE,
   MOCK_CHAT_LIST_FIRST_PAGE_RESPONSE,
   MOCK_CHAT_ITEM,
+  MOCK_CHAT_LIST_WITH_WITHDRAWN_RESPONSE,
 } from "@/mock/data/chat.data";
 import { addRefreshCookie, setupProtectedSessionMocks } from "./utils/auth";
 
@@ -60,6 +61,16 @@ test.describe("채팅 목록 페이지", () => {
     await expect(page).toHaveURL(/[?&]search=region/);
     await expect(page.getByRole("heading", { level: 2, name: "지역 선택" })).toBeVisible();
     await expect(page.getByPlaceholder("시/군/구를 입력해 주세요.")).toBeVisible();
+  });
+
+  test("탈퇴한 상대 채팅은 목록에 탈퇴 문구로 표시된다", async ({ context, page, baseURL }) => {
+    await addRefreshCookie(context, baseURL);
+    await setupChatListMocks(page, MOCK_CHAT_LIST_WITH_WITHDRAWN_RESPONSE);
+    await page.goto("/chat");
+
+    await expect(page.getByRole("heading", { level: 2, name: "채팅" })).toBeVisible();
+    await expect(page.getByText("탈퇴한 회원")).toBeVisible();
+    await expect(page.getByText(MOCK_CHAT_ITEM.postInfo.address)).toBeVisible();
   });
 
   test("채팅이 없을 때 빈 상태 문구가 표시된다", async ({ context, page, baseURL }) => {


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #1038
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 채팅 목록 탈퇴한 유저 채팅방에 "탈퇴한 회원"
- 채팅 상세 헤더 "탈퇴한 회원이에요", 채팅 input placeholder 추가 및 disabled 처리
- 채팅 상세 탈퇴 안내 토스트 표시
- 추가된 기능 테스트 코드 업데이트

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
