### PR TITLE
메인 바텀 시트 섹션 분기 높이 조절, 검색 empty UI 변경

### DIFF
--- a/src/app/(home)/_components/DefaultSheetContent/DefaultSheetContent.tsx
+++ b/src/app/(home)/_components/DefaultSheetContent/DefaultSheetContent.tsx
@@ -20,7 +20,7 @@ const DefaultSheetContent = ({ onSectionHeights }: DefaultSheetContentProps) => 
   const refs = useSectionHeights(onSectionHeights);
 
   return (
-    <div className="space-y-5">
+    <div ref={refs.contentRootRef} className="space-y-5">
       <div ref={refs.lostFindRef}>
         <LostFindActions />
       </div>

--- a/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
+++ b/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
@@ -31,7 +31,7 @@ const MainSearchEmpty = () => {
             {button.label}
             <Image
               src={button.icon}
-              alt={button.label}
+              alt=""
               width={50}
               height={70}
               className="absolute -top-1 left-0"

--- a/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
+++ b/src/app/(home)/_components/MainSearchEmpty/MainSearchEmpty.tsx
@@ -1,5 +1,8 @@
 import { Button, Icon } from "@/components/common";
+import { cn } from "@/utils";
+import Image from "next/image";
 import Link from "next/link";
+import { BUTTON_DEFAULT_STYLE, WRITE_BUTTONS } from "./WRITE_BUTTONS";
 
 const MainSearchEmpty = () => {
   return (
@@ -7,13 +10,35 @@ const MainSearchEmpty = () => {
       <div className="h-[54px] w-[54px] rounded-full border-[2.8px] border-white/30 backdrop-blur-[11.19px] bg-fill-brand-subtle-pressed flex-center">
         <Icon name="MainSearchWarning" size={48} className="mt-1" />
       </div>
-      <p className="text-h2-bold text-layout-header-default">검색어와 일치하는 결과가 없어요</p>
-      <span className="whitespace-pre-line text-center text-body2-regular text-layout-body-default">
-        {`찾으시는 물건이 아직 등록되지 않았네요.\n직접 글을 올려 더 많은 사람에게 알려보세요.`}
-      </span>
-      <Button as={Link} href="/list" variant="outlined" size="big">
-        게시글 살펴보러 가기
-      </Button>
+      <div className="gap-2 flex-col-center">
+        <p className="text-h2-bold text-layout-header-default">
+          검색한 위치에 등록된 분실물이 없어요
+        </p>
+        <span className="text-body2-regular text-layout-body-default">
+          직접 글을 올려 찾아줘에 등록할 수 있어요
+        </span>
+      </div>
+
+      <div className="w-full space-y-4">
+        {WRITE_BUTTONS.map((button) => (
+          <Button
+            key={button.label}
+            as={Link}
+            href={button.href}
+            ignoreBase
+            className={cn(BUTTON_DEFAULT_STYLE, button.style)}
+          >
+            {button.label}
+            <Image
+              src={button.icon}
+              alt={button.label}
+              width={50}
+              height={70}
+              className="absolute -top-1 left-0"
+            />
+          </Button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/app/(home)/_components/MainSearchEmpty/WRITE_BUTTONS.ts
+++ b/src/app/(home)/_components/MainSearchEmpty/WRITE_BUTTONS.ts
@@ -1,0 +1,17 @@
+export const BUTTON_DEFAULT_STYLE =
+  "block w-full rounded-2xl py-7 pl-[30px] text-h2-bold relative overflow-hidden";
+
+export const WRITE_BUTTONS = [
+  {
+    label: "분실한 물건 등록하기",
+    href: "/write/post?type=lost",
+    icon: "/main/LostFindActions/lost-position.svg",
+    style: "text-[#5B3322] bg-fill-accent-lostItem2",
+  },
+  {
+    label: "발견한 물건 등록하기",
+    href: "/write/post?type=find",
+    icon: "/main/LostFindActions/found-position.svg",
+    style: "text-[#173C28] bg-fill-brand-subtle-hover",
+  },
+];

--- a/src/app/(home)/_hooks/useSectionHeights/useSectionHeights.test.tsx
+++ b/src/app/(home)/_hooks/useSectionHeights/useSectionHeights.test.tsx
@@ -10,22 +10,25 @@ class ResizeObserverMock {
 describe("useSectionHeights", () => {
   let offsetHeightSpy: jest.SpyInstance;
   let offsetTopSpy: jest.SpyInstance;
+  let scrollHeightSpy: jest.SpyInstance;
 
   beforeEach(() => {
     global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
     offsetHeightSpy = jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(50);
     offsetTopSpy = jest.spyOn(HTMLElement.prototype, "offsetTop", "get").mockReturnValue(10);
+    scrollHeightSpy = jest.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(300);
   });
 
   afterEach(() => {
     offsetHeightSpy.mockRestore();
     offsetTopSpy.mockRestore();
+    scrollHeightSpy.mockRestore();
   });
 
   function Harness({ onMeasure }: { onMeasure: jest.Mock }) {
     const refs = useSectionHeights(onMeasure);
     return (
-      <div>
+      <div ref={refs.contentRootRef} data-testid="root">
         <div ref={refs.lostFindRef} data-testid="lost" />
         <div ref={refs.recentRef} data-testid="recent" />
         <div ref={refs.policeRef} data-testid="police" />
@@ -43,6 +46,7 @@ describe("useSectionHeights", () => {
         upToLostFindActions: 60,
         upToRecentFoundItemSection: 60,
         upToPoliceSection: 60,
+        totalContentHeight: 300,
       });
     });
   });
@@ -51,7 +55,7 @@ describe("useSectionHeights", () => {
     function EmptyHarness() {
       const refs = useSectionHeights(undefined);
       return (
-        <div>
+        <div ref={refs.contentRootRef}>
           <div ref={refs.lostFindRef} />
           <div ref={refs.recentRef} />
           <div ref={refs.policeRef} />

--- a/src/app/(home)/_hooks/useSectionHeights/useSectionHeights.ts
+++ b/src/app/(home)/_hooks/useSectionHeights/useSectionHeights.ts
@@ -2,35 +2,45 @@ import { useEffect, useRef } from "react";
 import { DefaultSheetContentHeights } from "../../_utils/heightUtils";
 
 const useSectionHeights = (onSectionHeights?: (heights: DefaultSheetContentHeights) => void) => {
+  const contentRootRef = useRef<HTMLDivElement>(null);
   const lostFindRef = useRef<HTMLDivElement>(null);
   const recentRef = useRef<HTMLDivElement>(null);
   const policeRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!onSectionHeights || !lostFindRef.current || !recentRef.current || !policeRef.current) {
+    if (
+      !onSectionHeights ||
+      !contentRootRef.current ||
+      !lostFindRef.current ||
+      !recentRef.current ||
+      !policeRef.current
+    ) {
       return;
     }
 
     const measure = () => {
+      const root = contentRootRef.current;
       const lost = lostFindRef.current;
       const recent = recentRef.current;
       const police = policeRef.current;
-      if (!lost || !recent || !police) return;
+      if (!root || !lost || !recent || !police) return;
 
       const upToLostFindActions = lost.offsetTop + lost.offsetHeight;
       const upToRecentFoundItemSection = recent.offsetTop + recent.offsetHeight;
       const upToPoliceSection = police.offsetTop + police.offsetHeight;
+      const totalContentHeight = root.scrollHeight;
 
       onSectionHeights({
         upToLostFindActions,
         upToRecentFoundItemSection,
         upToPoliceSection,
+        totalContentHeight,
       });
     };
 
     measure();
 
-    const observers = [lostFindRef, recentRef, policeRef].map((ref) => {
+    const observers = [contentRootRef, lostFindRef, recentRef, policeRef].map((ref) => {
       if (!ref.current) return null;
       const observer = new ResizeObserver(measure);
       observer.observe(ref.current);
@@ -43,6 +53,7 @@ const useSectionHeights = (onSectionHeights?: (heights: DefaultSheetContentHeigh
   }, [onSectionHeights]);
 
   return {
+    contentRootRef,
     lostFindRef,
     recentRef,
     policeRef,

--- a/src/app/(home)/_utils/heightUtils.ts
+++ b/src/app/(home)/_utils/heightUtils.ts
@@ -40,8 +40,8 @@ export const getSnapHeightsByContent = (
   const { upToLostFindActions, upToRecentFoundItemSection, upToPoliceSection, totalContentHeight } =
     contentHeights;
 
-  const peekAfterLost = (upToRecentFoundItemSection - upToLostFindActions) / 2;
-  const peekAfterRecent = (upToPoliceSection - upToRecentFoundItemSection) / 2;
+  const peekAfterLost = Math.max(0, upToRecentFoundItemSection - upToLostFindActions) / 2;
+  const peekAfterRecent = Math.max(0, upToPoliceSection - upToRecentFoundItemSection) / 2;
   const peekAfterPolice = Math.max(0, totalContentHeight - upToPoliceSection) / 2;
 
   const secondRaw = base + upToLostFindActions - CONTENT_SNAP_OFFSET_PX + peekAfterLost;

--- a/src/app/(home)/_utils/heightUtils.ts
+++ b/src/app/(home)/_utils/heightUtils.ts
@@ -17,6 +17,7 @@ export interface DefaultSheetContentHeights {
   upToLostFindActions: number;
   upToRecentFoundItemSection: number;
   upToPoliceSection: number;
+  totalContentHeight: number;
 }
 
 export const getSnapHeightsByDevice = (max: number): number[] => {
@@ -28,24 +29,29 @@ export const getSnapHeightsByDevice = (max: number): number[] => {
 
 const CONTENT_SNAP_OFFSET_PX = 40;
 
+const clampSheetHeight = (value: number, max: number) =>
+  Math.max(MIN_HEIGHT_PX, Math.min(max, value));
+
 export const getSnapHeightsByContent = (
   max: number,
   contentHeights: DefaultSheetContentHeights
 ): number[] => {
   const base = SHEET_HANDLE_HEIGHT_PX + SHEET_CONTENT_BOTTOM_PADDING_PX;
-  const h = contentHeights;
-  const second = Math.max(
-    MIN_HEIGHT_PX,
-    Math.min(max, base + h.upToLostFindActions - CONTENT_SNAP_OFFSET_PX)
-  );
-  const third = Math.max(
-    MIN_HEIGHT_PX,
-    Math.min(max, base + h.upToRecentFoundItemSection - CONTENT_SNAP_OFFSET_PX)
-  );
-  const fourth = Math.max(
-    MIN_HEIGHT_PX,
-    Math.min(max, base + h.upToPoliceSection - CONTENT_SNAP_OFFSET_PX)
-  );
+  const { upToLostFindActions, upToRecentFoundItemSection, upToPoliceSection, totalContentHeight } =
+    contentHeights;
+
+  const peekAfterLost = (upToRecentFoundItemSection - upToLostFindActions) / 2;
+  const peekAfterRecent = (upToPoliceSection - upToRecentFoundItemSection) / 2;
+  const peekAfterPolice = Math.max(0, totalContentHeight - upToPoliceSection) / 2;
+
+  const secondRaw = base + upToLostFindActions - CONTENT_SNAP_OFFSET_PX + peekAfterLost;
+  const thirdRaw = base + upToRecentFoundItemSection - CONTENT_SNAP_OFFSET_PX + peekAfterRecent;
+  const fourthRaw = base + upToPoliceSection - CONTENT_SNAP_OFFSET_PX + peekAfterPolice;
+
+  const second = clampSheetHeight(secondRaw, max);
+  const third = clampSheetHeight(Math.max(thirdRaw, second), max);
+  const fourth = clampSheetHeight(Math.max(fourthRaw, third), max);
+
   return [MIN_HEIGHT_PX, second, third, fourth, max];
 };
 


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #1040
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 메인페이지의 바텀 시트 분기 높이를 다음 섹션이 보이도록 수정
- 업데이트된 메인 empty UI를 적용

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
