### PR TITLE
GTM&GA 이벤트 트래킹 세팅

### DIFF
--- a/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
+++ b/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
@@ -10,6 +10,7 @@ import MainSearchLayout from "../MainSearchLayout/MainSearchLayout";
 import { DEFAULT_ADDRESS } from "@/constants";
 import { useGeolocationPermissionGranted } from "@/hooks";
 import { useMainKakaoMapStore, useMainRecentSearch } from "@/store";
+import { trackSearch } from "@/utils/analytics/analytics";
 
 interface LocationFormValues {
   search: string;
@@ -69,6 +70,7 @@ const HeaderSearchForm = ({
     const trimmedSearch = search.trim();
     if (!trimmedSearch) return;
     addRecentSearch(trimmedSearch);
+    trackSearch(trimmedSearch);
     router.push(`/?search=${encodeURIComponent(trimmedSearch)}`);
     setFocused(false);
   };

--- a/src/app/(route)/list/_components/DefaultListSearch/DefaultListSearch.tsx
+++ b/src/app/(route)/list/_components/DefaultListSearch/DefaultListSearch.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "@/app/ErrorBoundary";
 import { InputSearch } from "@/components/common";
 import { useInfiniteScroll } from "@/hooks";
 import { PostSearchView } from "./_internal";
+import { trackSearch } from "@/utils/analytics/analytics";
 
 const DefaultListSearch = () => {
   const router = useRouter();
@@ -39,6 +40,7 @@ const DefaultListSearch = () => {
 
     if (!value || value === keyword) return;
 
+    trackSearch(value);
     router.replace(`/list?search=post&keyword=${value}`);
   };
 

--- a/src/app/(route)/write/post/_hooks/usePostWriteSubmit/usePostWriteSubmit.ts
+++ b/src/app/(route)/write/post/_hooks/usePostWriteSubmit/usePostWriteSubmit.ts
@@ -3,6 +3,7 @@ import { UseFormReturn, useWatch } from "react-hook-form";
 import { useWriteStore } from "@/store";
 import { PostWriteFormValues } from "../../_types/PostWriteType";
 import { PostWriteRequest, usePostPosts } from "@/api/fetch/post";
+import { trackPostComplete } from "@/utils/analytics/analytics";
 
 interface UsePostWriteSubmitProps {
   methods: UseFormReturn<PostWriteFormValues>;
@@ -88,6 +89,7 @@ const usePostWriteSubmit = ({ methods }: UsePostWriteSubmitProps) => {
 
     if (!formData) return;
 
+    if (postType) trackPostComplete(postType as "분실물" | "습득물");
     postPosts(formData);
     clearLocation();
   };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import { Metadata } from "next";
 import MSWProvider from "@/providers/MSWProvider";
 import AuthBootstrap from "./authBootStrap";
 import { NotificationSSEProvider } from "@/providers/NotificationSSEProvider";
-import { GoogleAnalytics } from "@next/third-parties/google";
 import { PWAProvider } from "@/providers/PWAProvider";
 import { WebPushProvider } from "@/providers/WebPushProvider";
 import TermsProvider from "@/providers/TermsProvider";
@@ -59,7 +58,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const isProd = process.env.VERCEL_ENV === "production";
-  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
   const clarityId = process.env.NEXT_PUBLIC_CLARITY_ID;
 
   return (
@@ -75,7 +74,29 @@ export default function RootLayout({
         <meta name="naver-site-verification" content="6e6273a72b1c013d4f54c30896dbdb7a6ab63945" />
       </head>
       <body className="mx-auto max-w-[768px] border-x-2 flex-col-center">
-        {isProd && gaId && <GoogleAnalytics gaId={gaId} />}
+        {isProd && gtmId && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            />
+          </noscript>
+        )}
+        {isProd && gtmId && (
+          <Script
+            id="gtm-script"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${gtmId}');`,
+            }}
+          />
+        )}
         {isProd && clarityId && (
           <Script id="clarity-script" strategy="afterInteractive">
             {`

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Metadata } from "next";
 import MSWProvider from "@/providers/MSWProvider";
 import AuthBootstrap from "./authBootStrap";
 import { NotificationSSEProvider } from "@/providers/NotificationSSEProvider";
+import { GoogleTagManager } from "@next/third-parties/google";
 import { PWAProvider } from "@/providers/PWAProvider";
 import { WebPushProvider } from "@/providers/WebPushProvider";
 import TermsProvider from "@/providers/TermsProvider";
@@ -74,29 +75,7 @@ export default function RootLayout({
         <meta name="naver-site-verification" content="6e6273a72b1c013d4f54c30896dbdb7a6ab63945" />
       </head>
       <body className="mx-auto max-w-[768px] border-x-2 flex-col-center">
-        {isProd && gtmId && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-            />
-          </noscript>
-        )}
-        {isProd && gtmId && (
-          <Script
-            id="gtm-script"
-            strategy="afterInteractive"
-            dangerouslySetInnerHTML={{
-              __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','${gtmId}');`,
-            }}
-          />
-        )}
+        {isProd && gtmId && <GoogleTagManager gtmId={gtmId} />}
         {isProd && clarityId && (
           <Script id="clarity-script" strategy="afterInteractive">
             {`

--- a/src/utils/analytics/analytics.ts
+++ b/src/utils/analytics/analytics.ts
@@ -9,7 +9,7 @@ export const trackPostStart = (type: "분실물" | "습득물") =>
 export const trackPostComplete = (type: "분실물" | "습득물") =>
   trackingEvent({ action: "post_complete", category: "post", label: type });
 
-// 감섹 실행
+// 검색 실행
 export const trackSearch = (keyword: string) =>
   trackingEvent({ action: "search", category: "explore", label: keyword });
 

--- a/src/utils/analytics/analytics.ts
+++ b/src/utils/analytics/analytics.ts
@@ -1,0 +1,20 @@
+import { trackingEvent } from "../trackingEvent/trackingEvent";
+export { trackingEvent };
+
+export const trackPostStart = (type: "분실물" | "습득물") =>
+  trackingEvent({ action: "post_start", category: "post", label: type });
+
+export const trackPostComplete = (type: "분실물" | "습득물") =>
+  trackingEvent({ action: "post_complete", category: "post", label: type });
+
+export const trackSearch = (keyword: string) =>
+  trackingEvent({ action: "search", category: "explore", label: keyword });
+
+export const trackFilterChange = (filter: string) =>
+  trackingEvent({ action: "filter_change", category: "explore", label: filter });
+
+export const trackContactClick = (postId: string) =>
+  trackingEvent({ action: "contact_click", category: "conversion", label: postId });
+
+export const trackResolved = (type: "분실물" | "습득물") =>
+  trackingEvent({ action: "resolved", category: "conversion", label: type });

--- a/src/utils/analytics/analytics.ts
+++ b/src/utils/analytics/analytics.ts
@@ -1,20 +1,26 @@
 import { trackingEvent } from "../trackingEvent/trackingEvent";
 export { trackingEvent };
 
+// 글쓰게 페이지 진입
 export const trackPostStart = (type: "분실물" | "습득물") =>
   trackingEvent({ action: "post_start", category: "post", label: type });
 
+// 글쓰기 제출
 export const trackPostComplete = (type: "분실물" | "습득물") =>
   trackingEvent({ action: "post_complete", category: "post", label: type });
 
+// 감섹 실행
 export const trackSearch = (keyword: string) =>
   trackingEvent({ action: "search", category: "explore", label: keyword });
 
+// 필터 변경
 export const trackFilterChange = (filter: string) =>
   trackingEvent({ action: "filter_change", category: "explore", label: filter });
 
+// 입력하기 버튼 클릭
 export const trackContactClick = (postId: string) =>
   trackingEvent({ action: "contact_click", category: "conversion", label: postId });
 
+// 해결 완료
 export const trackResolved = (type: "분실물" | "습득물") =>
   trackingEvent({ action: "resolved", category: "conversion", label: type });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -32,3 +32,4 @@ export { isWebPushSupported } from "./webPush/isWebPushSupported/isWebPushSuppor
 export { registerWebPushServiceWorker } from "./webPush/registerWebPushServiceWorker/registerWebPushServiceWorker";
 export { syncWebPushSubscription } from "./webPush/syncWebPushSubscription/syncWebPushSubscription";
 export { unsubscribeWebPushFromServer } from "./webPush/unsubscribeWebPushFromServer/unsubscribeWebPushFromServer";
+export { trackingEvent } from "./trackingEvent/trackingEvent";

--- a/src/utils/trackingEvent/trackingEvent.ts
+++ b/src/utils/trackingEvent/trackingEvent.ts
@@ -1,5 +1,3 @@
-export const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
-
 declare global {
   interface Window {
     gtag: (command: string, action: string, params?: Record<string, unknown>) => void;

--- a/src/utils/trackingEvent/trackingEvent.ts
+++ b/src/utils/trackingEvent/trackingEvent.ts
@@ -1,0 +1,24 @@
+export const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+declare global {
+  interface Window {
+    gtag: (command: string, action: string, params?: Record<string, unknown>) => void;
+  }
+}
+
+type GTagEvent = {
+  action: string;
+  category: string;
+  label?: string;
+  value?: number;
+};
+
+export const trackingEvent = ({ action, category, label, value }: GTagEvent) => {
+  if (typeof window !== "undefined" && window.gtag) {
+    window.gtag("event", action, {
+      event_category: category,
+      event_label: label,
+      value,
+    });
+  }
+};


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #1042 

## 작업 내용

- GTM 방식과 GA를 둘 다 사용하는 하는 방향으로 작업했습니다.
- GoogleAnalytics 태그와 GoogleTagManger 태그가 동시 존재 시 이벤트를 2배로 수집하여 기존 코드는 삭제하고 GoogleTagManger로 대체했습니다.
- GA 방식을 사용하기 위해 검색, 글쓰기, 글쓰기 페이지 진입 이벤트만 시험적으로 연결했고, 우선 GA와 잘 연결이 되는지를 확인 후 나머지 이벤트들도 함께 진행할 예정입니다. (배포로만 확인이 가능하여 나눠서 진행하게 되었습니다.)
- 관련 내용은 작업이 마무리 되는 시기에 맞춰 컨플루언스에 해당 내용 추가할 예정입니다. 

## 참고 사항

- 환경변수 세팅 업데이트 필요합니다! 컨플루언스 확인해주세요

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
