### PR TITLE
manual, support 애니메이션 제거 후 css 변경 및 manual 내부 라우팅 링크 수정

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,8 +6,8 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   /* 테스트 실행 파일 위치 */
   testDir: "./tests/e2e",
-  /* 파일 단위로 테스트를 병렬 실행한다 */
-  fullyParallel: true,
+  /* 파일 단위로 테스트를 순차 실행한다 */
+  fullyParallel: false,
   /* CI 환경에서 test.only가 source code에 남아있을 경우 build를 실패시킨다 */
   forbidOnly: !!process.env.CI,
   /* CI 환경에서 테스트를 재시도한다 */

--- a/src/app/(route)/manual/_components/ManualList/ManualList.test.tsx
+++ b/src/app/(route)/manual/_components/ManualList/ManualList.test.tsx
@@ -64,9 +64,6 @@ describe("ManualList", () => {
     buttons.forEach((btn) => {
       expect(btn).toHaveAttribute("aria-expanded", "false");
     });
-
-    expect(screen.queryByText("카드사에 분실신고가 필요해요.")).not.toBeInTheDocument();
-    expect(screen.queryByText("lost112에서 확인해 보세요.")).not.toBeInTheDocument();
   });
 
   test("아이템 클릭 시 해당 패널이 열리고, 다시 클릭하면 닫힌다", async () => {

--- a/src/app/(route)/manual/_components/ManualList/ManualList.tsx
+++ b/src/app/(route)/manual/_components/ManualList/ManualList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/utils";
 import { Button, Icon } from "@/components/common";
 import { ManualItemType } from "../../_types/ManualType";
@@ -57,32 +56,29 @@ const ManualItem = ({ item, isOpen, onToggle }: ManualItemProps) => {
           <Icon name="ArrowDown" />
         </span>
       </button>
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.3 }}
-            className="w-full overflow-hidden bg-fill-neutral-strong-default"
-          >
-            <div className="flex flex-col items-start justify-center px-[20px] py-[24px] text-body2-regular text-layout-body-default">
-              <p className="mb-[26px]">{content}</p>
-              {href && (
-                <Link
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center gap-[6px] rounded-[10px] border border-neutral-normal-default bg-white py-[10px] text-center text-body2-semibold text-neutral-normal-default"
-                >
-                  {btnText}
-                  <Icon name="ArrowRightSmall" size={20} className="text-neutral-normal-default" />
-                </Link>
-              )}
-            </div>
-          </motion.div>
+      <div
+        className={cn(
+          "grid w-full transition-all duration-300 bg-fill-neutral-strong-default",
+          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
         )}
-      </AnimatePresence>
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-col items-start justify-center px-[20px] py-[24px] text-body2-regular text-layout-body-default">
+            <p className="mb-[26px]">{content}</p>
+            {href && (
+              <Link
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex w-full items-center justify-center gap-[6px] rounded-[10px] border border-neutral-normal-default bg-white py-[10px] text-center text-body2-semibold text-neutral-normal-default"
+              >
+                {btnText}
+                <Icon name="ArrowRightSmall" size={20} className="text-neutral-normal-default" />
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
     </li>
   );
 };

--- a/src/app/(route)/manual/_constants/MANUAL_CONSTANT.tsx
+++ b/src/app/(route)/manual/_constants/MANUAL_CONSTANT.tsx
@@ -35,7 +35,7 @@ export const MANUAL_DATA: Manual = {
       content: (
         <>'찾아줘'에 분실 게시물을 작성하면 물건을 습득한 분이 게시글을 통해 연락할 수 있어요.</>
       ),
-      href: "https://www.finditem.kr/write/post?type=lost/",
+      href: "https://www.finditem.kr/write/post?type=lost",
       btnText: "분실 게시글 쓰러가기",
     },
     {
@@ -71,7 +71,7 @@ export const MANUAL_DATA: Manual = {
           신청을 할 수 있어요.
         </>
       ),
-      href: "www.minwon.go.kr",
+      href: "https://plus.gov.kr",
       btnText: "민원 24 바로가기",
     },
     {
@@ -80,11 +80,11 @@ export const MANUAL_DATA: Manual = {
         <>
           핸드폰 분실 시 통신사 고객센터(114)나 직영대리점, 통신사 홈페이지를 통해 분실신고와
           발신정지를 해야 해요. <br />
-          <br /> 또한 핸드폰 찾기 콜센터(https://www.handphone.co.kr/lostinfo.php)에서 핸드폰
-          습득물을 조회할 수 있어요.
+          <br /> 또한 핸드폰 찾기 콜센터(https://www.handphone.or.kr)에서 핸드폰 습득물을 조회할 수
+          있어요.
         </>
       ),
-      href: "https://www.handphone.co.kr/lostinfo.php",
+      href: "https://www.handphone.or.kr",
       btnText: "핸드폰 습득물 보러가기",
     },
   ],
@@ -93,11 +93,11 @@ export const MANUAL_DATA: Manual = {
       title: "경찰청 신고 내역을 확인했나요?",
       content: (
         <>
-          경찰청 유실물 종합 포털(https://www.lost112.go.kr/)에서 분실 신고가 접수된 유실물 목록을
+          경찰청 유실물 종합 포털(https://www.lost112.go.kr)에서 분실 신고가 접수된 유실물 목록을
           확인해 보세요.
         </>
       ),
-      href: "https://www.lost112.go.kr/",
+      href: "https://www.lost112.go.kr",
       btnText: "경찰청 바로가기",
     },
     {
@@ -115,11 +115,11 @@ export const MANUAL_DATA: Manual = {
       title: "습득물 신고를 하셨나요?",
       content: (
         <>
-          물건을 습득한 경우 경찰청 유실물 종합 포털(https://www.lost112.go.kr/)이나 가까운 경찰서에
+          물건을 습득한 경우 경찰청 유실물 종합 포털(https://www.lost112.go.kr)이나 가까운 경찰서에
           방문하여 습득 신고를 할 수 있어요.
         </>
       ),
-      href: "https://www.lost112.go.kr/",
+      href: "https://www.lost112.go.kr",
       btnText: "습득 신고 하러가기",
     },
   ],
@@ -128,11 +128,11 @@ export const MANUAL_DATA: Manual = {
       title: "경찰청 습득물 목록을 확인했나요?",
       content: (
         <>
-          먼저 경찰청 유실물 종합 포털(https://www.lost112.go.kr/)을 통해 경찰청에서 보관 중인
+          먼저 경찰청 유실물 종합 포털(https://www.lost112.go.kr)을 통해 경찰청에서 보관 중인
           유실물을 확인해 보세요.
         </>
       ),
-      href: "https://www.lost112.go.kr/",
+      href: "https://www.lost112.go.kr",
       btnText: "경찰청 바로가기",
     },
     {

--- a/src/app/(route)/notice/[id]/_components/NoticeDetailHeader/NoticeDetailHeader.tsx
+++ b/src/app/(route)/notice/[id]/_components/NoticeDetailHeader/NoticeDetailHeader.tsx
@@ -30,7 +30,7 @@ const NoticeDetailHeader = ({ id }: { id: number }) => {
     likeCount: likeCount || 0,
     commentCount: commentCount || 0,
     viewCount: viewCount || 0,
-    link: window.location.href,
+    link: typeof window !== "undefined" ? window.location.href : "",
   };
 
   return (

--- a/src/app/(route)/support/_components/SupportFaqAccordion/SupportFaqAccordion.test.tsx
+++ b/src/app/(route)/support/_components/SupportFaqAccordion/SupportFaqAccordion.test.tsx
@@ -44,13 +44,6 @@ jest.mock("../SupportTab/_internal/useSupportTabQuery", () => ({
   useSupportTabQuery: () => mockUseSupportTabQuery(),
 }));
 
-jest.mock("framer-motion", () => ({
-  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  motion: {
-    div: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-  },
-}));
-
 jest.mock("@/components/common", () => ({
   Icon: () => null,
   Chip: ({ label }: { label: string }) => <span data-testid="faq-chip">{label}</span>,
@@ -120,8 +113,8 @@ describe("SupportFaqAccordion", () => {
     render(<SupportFaqAccordion />);
     const toggles = screen.getAllByRole("link", { name: "FAQ 질문 접기/펼치기" });
     fireEvent.click(toggles[0]);
-    expect(screen.getByTestId("faq-chip")).toHaveTextContent("전체");
+    expect(toggles[0]).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(toggles[0]);
-    expect(screen.queryByTestId("faq-chip")).not.toBeInTheDocument();
+    expect(toggles[0]).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/src/app/(route)/support/_components/SupportFaqAccordion/SupportFaqAccordion.tsx
+++ b/src/app/(route)/support/_components/SupportFaqAccordion/SupportFaqAccordion.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
 import { Button, Chip, Icon } from "@/components/common";
 import { cn } from "@/utils";
 import {
@@ -58,39 +57,35 @@ const SupportFaqAccordionItem = ({ item, isExpanded, onToggle }: SupportFaqAccor
         </a>
       </div>
 
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            key="content"
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.2 }}
-            className="w-full overflow-hidden"
-          >
-            <div className="flex flex-col gap-4 border-b border-neutral-normal-default px-5 py-6 bg-fill-neutral-subtle-default">
-              <div className="inline-block">
-                <Chip label={item.category} type="brandSubtleDefault" />
-              </div>
-
-              <div className="flex flex-col gap-[26px] text-body2-regular text-layout-body-default">
-                <span className="block whitespace-pre-line">{item.answer}</span>
-                {item.link && (
-                  <Button
-                    as={Link}
-                    href={item.link.href}
-                    variant="outlined"
-                    className="!gap-[6px] bg-fill-neutral-normal-default"
-                  >
-                    {item.link.text}
-                    <Icon name="ArrowRightSmall" size={18} />
-                  </Button>
-                )}
-              </div>
-            </div>
-          </motion.div>
+      <div
+        className={cn(
+          "grid w-full transition-all duration-200",
+          isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
         )}
-      </AnimatePresence>
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-col gap-4 border-b border-neutral-normal-default px-5 py-6 bg-fill-neutral-subtle-default">
+            <div className="inline-block">
+              <Chip label={item.category} type="brandSubtleDefault" />
+            </div>
+
+            <div className="flex flex-col gap-[26px] text-body2-regular text-layout-body-default">
+              <span className="block whitespace-pre-line">{item.answer}</span>
+              {item.link && (
+                <Button
+                  as={Link}
+                  href={item.link.href}
+                  variant="outlined"
+                  className="!gap-[6px] bg-fill-neutral-normal-default"
+                >
+                  {item.link.text}
+                  <Icon name="ArrowRightSmall" size={18} />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
     </li>
   );
 };

--- a/tests/e2e/manual.spec.ts
+++ b/tests/e2e/manual.spec.ts
@@ -71,9 +71,13 @@ test.describe("매뉴얼 페이지", () => {
   test("항목에 외부 링크 버튼이 표시된다", async ({ page }) => {
     await page.goto("/manual");
 
-    await page.getByRole("button", { name: "경찰청 신고 내역을 확인했나요?" }).click();
+    const section = page.getByRole("listitem").filter({
+      hasText: "경찰청 신고 내역을 확인했나요?",
+    });
 
-    await expect(page.getByRole("link", { name: "경찰청 바로가기" })).toBeVisible({
+    await section.getByRole("button", { name: "경찰청 신고 내역을 확인했나요?" }).click();
+
+    await expect(section.getByRole("link", { name: "경찰청 바로가기" })).toBeVisible({
       timeout: 3000,
     });
   });

--- a/tests/e2e/support-faq.spec.ts
+++ b/tests/e2e/support-faq.spec.ts
@@ -78,6 +78,6 @@ test.describe("자주 묻는 질문 (/support)", () => {
 
     await page.getByRole("link", { name: /1:1 문의하기/ }).click();
 
-    await expect(page).toHaveURL(/\/inquiry-write$/);
+    await expect(page).toHaveURL(/\/inquiry-write$/, { timeout: 15000 });
   });
 });


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `manual`, `support` 페이지에서 `framer-motion` 기반 애니메이션을 제거했습니다.
- 애니메이션 제거에 맞춰 CSS 스타일을 조정했습니다.
- `manual` 페이지의 내부 라우팅 링크를 수정했습니다.

## 참고 사항

- 두 페이지에서 동일한 애니메이션 패턴을 사용하고 있어 함께 수정했습니다.
- `framer-motion` 제거로 각 페이지의 번들 크기가 감소했습니다.

| 페이지 | 변경 전 | 변경 후 | 차이 |
|---|---:|---:|---:|
| `/manual` | 594 kB | 552 kB | -42 kB |
| `/support` | 492 kB | 449 kB | -43 kB |

<br class="Apple-interchange-newline">

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
