### PR TITLE
프로덕션 환경 console 출력 제한

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,9 @@ const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true,
   },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
+  },
   async rewrites() {
     if (!apiBaseUrl) {
       return [];

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,7 +36,7 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
   },
   compiler: {
-    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
+    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error", "warn"] } : false,
   },
   async rewrites() {
     if (!apiBaseUrl) {


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 프로덕션 환경에서 `console.log`, `console.warn`, `console.info`, `console.debug`가 출력되지 않도록 설정했습니다.
- 실제 에러 추적이 필요한 경우를 고려해 `console.error`는 유지했습니다.

## 참고 사항

- 기능 변경은 없습니다.
- 프로덕션 환경에서 일반 디버깅 로그가 노출되지 않도록 정리한 작업입니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
