### PR TITLE
GA 직접 이벤트 트래킹 세팅

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { Metadata } from "next";
 import MSWProvider from "@/providers/MSWProvider";
 import AuthBootstrap from "./authBootStrap";
 import { NotificationSSEProvider } from "@/providers/NotificationSSEProvider";
-import { GoogleTagManager } from "@next/third-parties/google";
+import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import { PWAProvider } from "@/providers/PWAProvider";
 import { WebPushProvider } from "@/providers/WebPushProvider";
 import TermsProvider from "@/providers/TermsProvider";
@@ -80,6 +80,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const isProd = process.env.VERCEL_ENV === "production";
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
   const clarityId = process.env.NEXT_PUBLIC_CLARITY_ID;
 
@@ -96,6 +97,7 @@ export default function RootLayout({
         <meta name="naver-site-verification" content="6e6273a72b1c013d4f54c30896dbdb7a6ab63945" />
       </head>
       <body className="mx-auto max-w-[768px] border-x-2 flex-col-center">
+        {isProd && gaId && <GoogleAnalytics gaId={gaId} />}
         {isProd && gtmId && <GoogleTagManager gtmId={gtmId} />}
         {isProd && clarityId && (
           <Script id="clarity-script" strategy="afterInteractive">


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `<GoogleAnalytics />` 와  `<GoogleTagManager />` 가 동시 존재하게 될 시, 이벤트가 동시 수집되는 문제(이벤트 2배로 수집)가 있어 제거했으나 GA 직접 이벤트 트래킹 코드가 GA4로 반영이 되지 않는 문제가 있었습니다.
- 알아보니 <GoogleAnalytics />태그를 추가해야 해당 코드들이 반영이 될것이라고 추측되었고,  GA4 사이트 설정에서 이벤트 수집 제외를 선택할 수 있다는것을 알게 되었습니다. 
- GA4 사이트에서 이벤트 집계가 2배가 되지 않도록 설정해두었으며 머지 된후 GA4에 반영되는지 확인이 필요합니다.

## 참고 사항

- <!-- 리뷰어가 알아야 할 맥락이나 주의할 점이 있다면 작성해주세요. -->

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
