### PR TITLE
메인페이지 검색: 일부 주소 검색가능, 방향키 이동 수정

### DIFF
--- a/src/api/fetch/mapController/api/useSearchLocation.ts
+++ b/src/api/fetch/mapController/api/useSearchLocation.ts
@@ -14,6 +14,7 @@ const SEARCH_LOCATION_PAGE_SIZE = 10;
 interface UseSearchLocationParams {
   latitude: number;
   longitude: number;
+  keyword?: string;
 }
 
 const useSearchLocation = ({ latitude, longitude }: UseSearchLocationParams) => {
@@ -25,6 +26,7 @@ const useSearchLocation = ({ latitude, longitude }: UseSearchLocationParams) => 
   const postStatus = searchParams.get("postStatus");
   const category = searchParams.get("category");
   const apiCategory = category?.toUpperCase();
+  const keyword = searchParams.get("search");
 
   const queryKey = [
     "search-location-posts",
@@ -34,6 +36,7 @@ const useSearchLocation = ({ latitude, longitude }: UseSearchLocationParams) => 
     apiPostType ?? "all",
     postStatus ?? "",
     apiCategory ?? "",
+    keyword ?? "",
   ] as const;
 
   const buildQueryString = (pageParam: MapPostSummaryPageParam) => {
@@ -51,6 +54,9 @@ const useSearchLocation = ({ latitude, longitude }: UseSearchLocationParams) => 
     }
     if (apiCategory) {
       params.set("category", apiCategory);
+    }
+    if (keyword) {
+      params.set("keyword", keyword);
     }
     if (pageParam) {
       params.set("lastDistance", String(pageParam.lastDistance));

--- a/src/api/fetch/mapController/api/useSearchLocation.ts
+++ b/src/api/fetch/mapController/api/useSearchLocation.ts
@@ -14,7 +14,6 @@ const SEARCH_LOCATION_PAGE_SIZE = 10;
 interface UseSearchLocationParams {
   latitude: number;
   longitude: number;
-  keyword?: string;
 }
 
 const useSearchLocation = ({ latitude, longitude }: UseSearchLocationParams) => {

--- a/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
+++ b/src/app/(home)/_components/MainSearchHeader/MainSearchHeader.tsx
@@ -123,6 +123,7 @@ const HeaderSearchForm = ({
           searchRegister.onChange(e);
           setSearchKeyword(e.target.value);
         }}
+        autoComplete="off"
         type="text"
         onFocus={() => {
           setFocused(true);


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 기존 메인페이지 검색 API가 좌표 기준만으로 동작했기에 전체 주소에 정확하게 일치하는 게시글만 조회되는 문제가 있어, `useSearchLoaction` 훅에 `keyword`라는 주소 쿼리스트링을 추가해 일부 주소 입력으로 게시글 조회가 가능하도록 추가했습니다.
- 구현되어 있던 최근 검색어, 자동 완성 리스트 방향키 이동이 브라우저 기본 최근 검색어와 충돌하는 상황에서 브라우저 최근 검색어가 우선 인식되어 리스트 방향키 동작에 충돌이 있었습니다. 
- 메인 검색 input에 autoComplete 옵션을 꺼, 브라우저 기본 자동완성 목록이 있을 때 자동완성/최근 검색어 방향키 이동이 안되던 문제를 해결했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
