### PR TITLE
채팅: WS dead code 삭제, 지역 검색 모드 replace -> push

### DIFF
--- a/src/api/fetch/chatRoom/api/chatSocket.ts
+++ b/src/api/fetch/chatRoom/api/chatSocket.ts
@@ -241,20 +241,10 @@ export const subscribeChatSocket = <T>(destination: string, handler: MessageHand
   subscribe();
 };
 
-export const unsubscribeChatSocket = (destination: string, handler?: MessageHandler) => {
-  if (handler) {
-    handlers.get(destination)?.delete(handler);
-    savedSubscriptions.get(destination)?.delete(handler);
-    if (handlers.get(destination)?.size === 0) {
-      const subscription = subscriptions.get(destination);
-      if (subscription) {
-        subscription.unsubscribe();
-        subscriptions.delete(destination);
-        handlers.delete(destination);
-        savedSubscriptions.delete(destination);
-      }
-    }
-  } else {
+export const unsubscribeChatSocket = (destination: string, handler: MessageHandler) => {
+  handlers.get(destination)?.delete(handler);
+  savedSubscriptions.get(destination)?.delete(handler);
+  if (handlers.get(destination)?.size === 0) {
     const subscription = subscriptions.get(destination);
     if (subscription) {
       subscription.unsubscribe();

--- a/src/api/fetch/chatRoom/api/useChatSocket.ts
+++ b/src/api/fetch/chatRoom/api/useChatSocket.ts
@@ -7,7 +7,6 @@ import { ChatListUpdateResponse, WebSocketChatMessage } from "../types/ChatRoomR
 interface UseChatSocketOptions {
   onMessage?: (data: WebSocketChatMessage) => void;
   onListUpdate?: (data: ChatListUpdateResponse) => void;
-  onReadReceipt?: (data: any) => void;
   manageConnection?: boolean;
 }
 
@@ -24,7 +23,6 @@ const scheduleDeferredConnect = (task: () => void) => {
 export const useChatSocket = ({
   onMessage,
   onListUpdate,
-  onReadReceipt,
   manageConnection = false,
 }: UseChatSocketOptions = {}) => {
   useEffect(() => {
@@ -35,7 +33,6 @@ export const useChatSocket = ({
     const subscriptions = [
       { destination: "/user/queue/messages", handler: onMessage },
       { destination: "/user/queue/list-updates", handler: onListUpdate },
-      { destination: "/user/queue/read-receipts", handler: onReadReceipt },
     ];
 
     const init = async () => {
@@ -77,5 +74,5 @@ export const useChatSocket = ({
         }
       });
     };
-  }, [onMessage, onListUpdate, onReadReceipt, manageConnection]);
+  }, [onMessage, onListUpdate, manageConnection]);
 };

--- a/src/api/fetch/chatRoom/index.ts
+++ b/src/api/fetch/chatRoom/index.ts
@@ -1,8 +1,3 @@
 export { default as useChatList } from "./api/useChatList";
 export { useChatSocket } from "./api/useChatSocket";
-export {
-  connectChatSocket,
-  disconnectChatSocket,
-  subscribeChatSocket,
-  sendChatSocketMessage,
-} from "./api/chatSocket";
+export { sendChatSocketMessage } from "./api/chatSocket";

--- a/src/app/(route)/chat/_components/ListView/ListView.tsx
+++ b/src/app/(route)/chat/_components/ListView/ListView.tsx
@@ -13,7 +13,7 @@ const ListSearch = dynamic(() => import("../ListSearch/ListSearch"), {
 });
 
 const ListViewContent = () => {
-  const { searchMode, searchUpdateQuery } = useSearchUpdateQueryString("replace");
+  const { searchMode, searchUpdateQuery } = useSearchUpdateQueryString("push");
   const queryClient = useQueryClient();
 
   useChatSocket({


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- REST API로 사용되는 채팅 읽음 기능 떄문에 사용하지 않고 있던 useChatSocket의 onReadReceipt 옵션 및 구독 코드 제거
- 채팅 지역선택에서 뒤로 가기가 동작될 때 메인페이지로 이동되는 문제를 해결하기 위해, 채팅 목록 지역선택 라우팅 전환을 replace -> push로 변경하여 해결했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
