### PR TITLE
웹 푸쉬 알림 기능 수정

### DIFF
--- a/src/api/fetch/webPush/types/webPushType.ts
+++ b/src/api/fetch/webPush/types/webPushType.ts
@@ -2,10 +2,8 @@ import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
 
 export interface PostPushSubscribeRequest {
   endpoint: string;
-  keys: {
-    p256dh: string;
-    auth: string;
-  };
+  p256dh: string;
+  auth: string;
 }
 
 export interface PostPushSubscribeResponse extends ApiBaseResponseType<string> {}

--- a/src/utils/webPush/syncWebPushSubscription/syncWebPushSubscription.test.ts
+++ b/src/utils/webPush/syncWebPushSubscription/syncWebPushSubscription.test.ts
@@ -69,7 +69,8 @@ describe("syncWebPushSubscription", () => {
     );
     expect(mockPost).toHaveBeenCalledWith("/push/subscribe", {
       endpoint: "https://ep",
-      keys: { p256dh: "dh", auth: "au" },
+      p256dh: "dh",
+      auth: "au",
     });
   });
 

--- a/src/utils/webPush/syncWebPushSubscription/syncWebPushSubscription.ts
+++ b/src/utils/webPush/syncWebPushSubscription/syncWebPushSubscription.ts
@@ -55,10 +55,8 @@ export const syncWebPushSubscription = async (): Promise<void> => {
 
   const body: PostPushSubscribeRequest = {
     endpoint: json.endpoint,
-    keys: {
-      p256dh: json.keys.p256dh,
-      auth: json.keys.auth,
-    },
+    p256dh: json.keys.p256dh,
+    auth: json.keys.auth,
   };
 
   const { data: subRes } = await authApi.post("/push/subscribe", body);


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- p256dh, auth를 keys 객체 중첩이 아닌 최상위 필드로 전송하게 수정했습니다.
- 구독 등록 실패로 서버에 push endpoint가 저장되지 않던 문제를 해결했습니다. DevTools Push는 SW만 검증하므로 정상처럼 보였지만, 실제 알림 유발 시 웹 푸쉬가 오지 않던 현상의 원인이었습니다.

## 참고 사항

- 현재 로컬환경에서 두 계정으로 채팅 전송을 통해 웹 푸쉬가 동작하는 것을 확인한 상태입니다.
- 배포 환경에서의 웹 푸쉬 동작과 PWA 알림 동작을 추가로 검증해야 합니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
