### PR TITLE
깃허브 액션 개인 토큰을 GitHub App 토큰으로 교체

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -10,9 +10,16 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Assign issue to author
         uses: pozil/auto-assign-issue@v2
         with:
-          repo-token: ${{ secrets.YML_GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           assignees: ${{ github.event.issue.user.login }}
           allowSelfAssign: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,7 +11,14 @@ jobs:
   addReviewers:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: kentaro-m/auto-assign-action@v2.0.1
         with:
-          repo-token: ${{ secrets.YML_GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/auto_assign.yml

--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -12,8 +12,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: drafter-config.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.YML_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/hotfix-sync.yml
+++ b/.github/workflows/hotfix-sync.yml
@@ -14,6 +14,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Sync PR to Develop
         uses: repo-sync/pull-request@v2
         with:
@@ -22,7 +29,7 @@ jobs:
           pr_title: "[Hotfix] develop 최신화"
           pr_body: "운영 환경(main)의 긴급 수정 사항을 develop 브랜치에 반영합니다."
           pr_label: "hotfix-sync"
-          github_token: ${{ secrets.YML_GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Create Sync PR to Release
         uses: repo-sync/pull-request@v2
@@ -32,4 +39,4 @@ jobs:
           pr_title: "[Hotfix] release 최신화"
           pr_body: "운영 환경(main)의 긴급 수정 사항을 release 브랜치에 반영합니다."
           pr_label: "hotfix-sync"
-          github_token: ${{ secrets.YML_GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create or Update Pull Request
         uses: repo-sync/pull-request@v2
         with:
@@ -22,4 +29,4 @@ jobs:
             ## 작업 요약
             Develop 브랜치의 최신 변경 사항을 Release 브랜치로 반영합니다.
           pr_label: "🌱 release"
-          github_token: ${{ secrets.YML_GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- GitHub Actions에서 사용하던 개인 토큰을 제거했습니다.
- 자동 PR 생성에 사용할 `finditem-bot` GitHub App을 추가했습니다.
- 자동화로 생성되는 PR 작성자가 개인 계정이 아닌 `finditem-bot[bot]`으로 표시되도록 구성했습니다.

## 참고 사항

- 머지 후 깃허브 액션이 정상 동작 하는지 테스트가 필요합니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
