### PR TITLE
로그아웃 후 바로 로그인 가능하도록 수정

### DIFF
--- a/src/app/(route)/mypage/layout.tsx
+++ b/src/app/(route)/mypage/layout.tsx
@@ -18,7 +18,7 @@ export default async function layout({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();
 
   const cookieStore = await cookies();
-  const hasToken = cookieStore.has("accessToken");
+  const hasToken = cookieStore.has("access_token");
 
   if (hasToken) {
     try {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,7 +34,7 @@ export function middleware(request: NextRequest) {
   }
 
   // 엑세스 토큰이 있는데 로그인, 회원가입 페이지에 접근하려고 할때 마이페이지로 리다이렉트 (리프레쉬 토큰 만료됐을때는 제외)
-  const RedirectMypage = isAuthPath && accessToken && !isSessionExpired;
+  const RedirectMypage = isAuthPath && accessToken && refreshToken && !isSessionExpired;
   if (RedirectMypage) {
     return NextResponse.redirect(new URL("/mypage", request.url));
   }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 로그아웃 후, 즉시 로그인 버튼을 클릭했을때 로그인 화면으로 리다이렉트 되지 않는 에러 수정
- 마이페이지로 리다이렉트 되는 조건에 리프레쉬 토큰의 존재 유무를 포함하여 리프레쉬 토큰이 존재하면 마이페이지로 리다이렉트 되는것을 방지
- 오타가 있어서 수정했습니다
## 참고 사항

- 로컬에서는 작동하나 릴리즈 환경에서 테스트가 필요할것 같습니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/스토리북/테스트 통과
- [ ] 불필요한 코드/주석 제거
