### PR TITLE
로컬 SSE 연결 문제 해결

### DIFF
--- a/src/api/fetch/notification/api/notificationSSEClient.ts
+++ b/src/api/fetch/notification/api/notificationSSEClient.ts
@@ -4,7 +4,11 @@ import { retryBackoffController } from "@/utils/retryBackoffController/retryBack
 import type { NotificationEventData } from "../types/notificationSSETypes";
 
 const ACCESS_TOKEN_API_PATH = "/api/auth/access-token";
-const DEV_SSE_ACCESS_TOKEN_QUERY_KEY = "token";
+const SAME_ORIGIN_SSE_SUBSCRIBE_PATH = "/api/notifications/subscribe";
+
+const REMOTE_SSE_SUBSCRIBE_URL = process.env.NEXT_PUBLIC_API_URL
+  ? `${process.env.NEXT_PUBLIC_API_URL.replace(/\/$/, "")}/notifications/subscribe`
+  : "";
 
 const RUNTIME_KEY = "__fmi_notification_sse_runtime__";
 
@@ -61,11 +65,23 @@ export function setNotificationSSEHandlers(next: Partial<Handlers>) {
   Object.assign(handlers, next);
 }
 
-async function buildSubscribeUrl(): Promise<{ url: string; accessToken: string } | null> {
-  const apiBase = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
-  if (!apiBase) return null;
+const getNotificationSSESubscribeURL = (): string => {
+  if (typeof window === "undefined") return REMOTE_SSE_SUBSCRIBE_URL;
 
-  const subscribeUrl = `${apiBase}/notifications/subscribe`;
+  const { hostname } = window.location;
+  const isLocal = hostname === "localhost" || hostname === "127.0.0.1";
+
+  if (process.env.NODE_ENV !== "production" || isLocal) {
+    return SAME_ORIGIN_SSE_SUBSCRIBE_PATH;
+  }
+
+  return REMOTE_SSE_SUBSCRIBE_URL;
+};
+
+async function buildSubscribeUrl(): Promise<{ url: string; accessToken: string } | null> {
+  const subscribeUrl = getNotificationSSESubscribeURL();
+  if (!subscribeUrl) return null;
+
   const rt = getRuntime();
 
   try {
@@ -80,17 +96,6 @@ async function buildSubscribeUrl(): Promise<{ url: string; accessToken: string }
     if (!token) {
       rt.isAuthInvalid = true;
       return null;
-    }
-
-    const q = new URLSearchParams();
-    q.set(DEV_SSE_ACCESS_TOKEN_QUERY_KEY, token);
-    const shouldSendTokenByQuery = process.env.NODE_ENV === "development";
-
-    if (shouldSendTokenByQuery) {
-      return {
-        url: `${subscribeUrl}?${q.toString()}`,
-        accessToken: token,
-      };
     }
 
     return {


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용
로컬 개발 환경에서 알림 SSE 연결이 간헐적으로 실패하던 문제를 수정합니다.

기존에는 로컬에서 SSE가 api.finditem.kr에 직접 연결되면서 localhost 세션 토큰(?token=)과 finditem.kr 도메인 쿠키가 동시에 전달되어 인증이 충돌했습니다. 
채팅 WebSocket과 동일한 환경 분기 패턴을 적용해, 로컬에서는 same-origin 프록시(/api/notifications/subscribe)를 사용하고 프로덕션에서는 API 서버에 직접 연결하도록 변경했습니다.

배포 서버와 로컬에 각각 로그인한 이력이 있으면 finditem.kr 쿠키가 남아 있어 재현되기 쉬웠고, finditem.kr 쿠키를 수동 삭제하면 정상 연결되는 증상이 있었습니다.

## 기대 효과
로컬에서 배포 서버 로그인 이력이 있어도 SSE가 안정적으로 연결됨
일반 API·채팅 WebSocket과 동일한 인증 경로 사용 (localhost 쿠키 → /api 프록시)
프로덕션 동작은 기존과 동일 (API 직접 연결 + 쿠키 인증)


## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
