### PR TITLE
fix : 공공데이터 분실 조회시 발생하는 오류 임시방편 추가

### DIFF
--- a/src/app/[locale]/(route)/public-data/_components/_internal/PublicDataList/PublicDataList.tsx
+++ b/src/app/[locale]/(route)/public-data/_components/_internal/PublicDataList/PublicDataList.tsx
@@ -43,7 +43,7 @@ const PublicDataList = () => {
           iconName: "NoPosts",
           iconSize: 70,
         }}
-        title="조회된 데이터가 없습니다."
+        title={isError ? "현재 공공데이터를 불러올 수 없어요." : "조회된 데이터가 없습니다."}
       />
     );
   }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 공공데이터 분실 조회 관련 오류 발생에 대한 임시 방편 추가

## 참고 사항

- 접근자체를 막는 것 보다는, `isError` 상태일때 다른 `title`이 출력되는 방향으로 추가해뒀습니다.
- 현재 `조회된 데이터가 없습니다`로 모든 데이터 상태 통일, 수정시 오류 상태인 경우 `현재 공공데이터를 불러올 수 없어요.`로 변환되서 출력

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
