### PR TITLE
fix(public-data): 공공데이터포털 조회가 400으로 실패하는 문제 수정

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -17,6 +17,9 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
+  // 서버 런타임과 동일하게, 외부 API로는 트레이스 헤더를 전파하지 않는다.
+  tracePropagationTargets: [/^\//, /^https:\/\/(www\.|api\.|dev-api\.)?finditem\.kr/],
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -16,6 +16,11 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
+  // 미설정 시 SDK는 모든 아웃바운드 요청에 sentry-trace/baggage 헤더를 붙인다.
+  // 공공데이터포털 게이트웨이는 헤더 값에 environment= 토큰이 있으면 400을 반환하므로,
+  // 자체 도메인으로 나가는 요청에만 트레이스를 전파한다.
+  tracePropagationTargets: [/^\//, /^https:\/\/(www\.|api\.|dev-api\.)?finditem\.kr/],
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/src/app/api/public/found/route.ts
+++ b/src/app/api/public/found/route.ts
@@ -55,7 +55,15 @@ export async function GET(request: NextRequest) {
     });
 
     if (!response.ok) {
-      return NextResponse.json({ error: "포털 서버 연결 실패" }, { status: response.status });
+      // 게이트웨이 단계에서 차단되면 정상 응답과 다른 스키마가 오므로 정규식으로만 사유를 추출한다.
+      const errorBody = await response.text().catch(() => "");
+      const errMsg = errorBody.match(/<errMsg>([^<]*)<\/errMsg>/)?.[1];
+      const reasonCode = errorBody.match(/<returnReasonCode>([^<]*)<\/returnReasonCode>/)?.[1];
+
+      return NextResponse.json(
+        { error: errMsg || "포털 서버 연결 실패", code: reasonCode },
+        { status: response.status }
+      );
     }
 
     const responseText = await response.text();

--- a/src/app/api/public/lost/route.ts
+++ b/src/app/api/public/lost/route.ts
@@ -65,7 +65,15 @@ export async function GET(request: NextRequest) {
     });
 
     if (!response.ok) {
-      return NextResponse.json({ error: "포털 서버 연결 실패" }, { status: response.status });
+      // 게이트웨이 단계에서 차단되면 정상 응답과 다른 스키마가 오므로 정규식으로만 사유를 추출한다.
+      const errorBody = await response.text().catch(() => "");
+      const errMsg = errorBody.match(/<errMsg>([^<]*)<\/errMsg>/)?.[1];
+      const reasonCode = errorBody.match(/<returnReasonCode>([^<]*)<\/returnReasonCode>/)?.[1];
+
+      return NextResponse.json(
+        { error: errMsg || "포털 서버 연결 실패", code: reasonCode },
+        { status: response.status }
+      );
     }
 
     const responseText = await response.text();


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- 해당 이슈 없음 (운영 장애 대응)

## 작업 내용

- Sentry의 `tracePropagationTargets`를 자체 도메인으로 제한하여, 외부 API로 나가는 요청에 `sentry-trace`/`baggage` 헤더가 붙지 않도록 했습니다. (`sentry.server.config.ts`, `sentry.edge.config.ts`)
- 공공데이터포털 프록시 라우트가 게이트웨이 단계에서 차단됐을 때 포털이 내려주는 `errMsg`와 `returnReasonCode`를 응답에 포함하도록 했습니다. (`api/public/lost`, `api/public/found`)

## 참고 사항

### 증상

`/public-data?type=lost`에서 조회가 항상 실패했습니다. 응답은 `{"error":"포털 서버 연결 실패"}`뿐이라 원인 파악이 어려운 상태였습니다.

### 원인

공공데이터포털 게이트웨이가 요청 헤더 값에 `environment=` 토큰이 포함되면 `400 INVALID_REQUEST_PARAMETER_ERROR`를 반환하도록 바뀌었습니다. 헤더 이름과는 무관하며, 값에 그 토큰이 있는지만 봅니다.

```
헤더 없음                      200 NORMAL SERVICE.
sentry-trace만                 200 NORMAL SERVICE.
baggage: a=b                   200 NORMAL SERVICE.
x-foo: env=1                   200 NORMAL SERVICE.
baggage: sentry-environment=x  400 INVALID_REQUEST_PARAMETER_ERROR
x-foo: environment=1           400 INVALID_REQUEST_PARAMETER_ERROR
```

Sentry SDK는 `tracePropagationTargets`가 설정되지 않으면 모든 아웃바운드 요청에 `baggage` 헤더를 붙입니다. 그 안의 `sentry-environment` 항목이 위 조건에 걸렸습니다.

Sentry의 이 동작은 라우트가 추가된 시점부터 동일했고 그동안 문제가 없었습니다. 바뀐 것은 포털 쪽 정책이므로, 우리가 조정할 수 있는 지점인 트레이스 전파 범위를 좁히는 방향으로 대응했습니다.

### 로컬에서 재현되지 않는 이유

Sentry는 `enabled: isProd && !isE2E`라 로컬 개발 환경에서 비활성입니다. 헤더가 붙지 않으므로 `npm run dev`에서는 수정 전에도 정상 동작합니다. 프로덕션 빌드에서만 재현됩니다.

### 검증

프로덕션 빌드(`npm run build` + `next start`)로 확인했습니다. Sentry는 양쪽 모두 활성 상태입니다.

```
수정 전  lost 400 INVALID_REQUEST_PARAMETER_ERROR / found 400 (동일)
수정 후  lost 200 최신 데이터 / found 200 최신 데이터
```

재현 시 `.next/cache/fetch-cache`를 비워야 합니다. `next: { revalidate: 43200 }` 때문에 이전 성공 응답이 남아 있으면 실패가 가려집니다.

### 습득물도 함께 영향받고 있었습니다

차단 조건이 URL이 아니라 요청 헤더라서 `/api/public/found`도 동일하게 실패하고 있었습니다. 다만 found 라우트는 날짜 파라미터를 호출부가 준 경우에만 붙여 URL이 고정이라, 기본 쿼리 하나가 Data Cache에 남아 정상처럼 보였습니다. 실제로는 8월 1일에 멈춘 데이터를 내려주고 있었고, 필터나 페이지를 바꾸면 바로 실패했습니다. lost 라우트는 오늘 날짜를 항상 붙여 캐시 키가 매일 바뀌므로 처음부터 노출된 것입니다.

### develop의 임시 조치와의 관계

develop에는 에러 문구를 바꾸는 임시 조치(#1144)가 이미 반영되어 있습니다. 코드가 겹치지 않아 충돌은 없으며, 이 PR이 배포된 뒤 해당 문구를 유지할지는 별도로 판단하면 됩니다.

### base가 main인 이유

`hotfix-sync.yml`이 `hotfix/*` 브랜치의 main 머지를 기준으로 develop과 release 동기화 PR을 생성하므로 그 흐름을 따랐습니다. main은 2026-06-22 이후 배포된 적이 없어, 이 PR은 그 빌드 위에 위 4개 파일 변경만 얹습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인 (프로덕션 빌드로 수정 전후 비교)
- [x] 로컬 빌드/테스트 통과 (`npm run build`, `npx tsc --noEmit`, `jest --testPathPattern public-data` 8 suites / 83 tests) — 스토리북은 변경 범위와 무관하여 실행하지 않았습니다
- [x] 불필요한 코드/주석 제거
