### PR TITLE
chore: 미사용 상수 정리 및 Storybook next-intl 데코레이터 추가

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,18 @@
 import type { Preview } from "@storybook/nextjs";
+import React from "react";
+import { NextIntlClientProvider } from "next-intl";
 import "../src/app/globals.css";
+import koMessages from "../src/messages/ko.json";
 
 const preview: Preview = {
+  decorators: [
+    (Story) =>
+      React.createElement(
+        NextIntlClientProvider,
+        { locale: "ko", messages: koMessages },
+        React.createElement(Story)
+      ),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/src/app/[locale]/(route)/login/email/_constants/CHECKBOX_CONFIG.ts
+++ b/src/app/[locale]/(route)/login/email/_constants/CHECKBOX_CONFIG.ts
@@ -1,4 +1,0 @@
-export const CHECKBOX_CONFIG = [
-  { label: "아이디 기억하기", id: "rememberId" },
-  { label: "자동 로그인", id: "autoLogin" },
-] as const;

--- a/src/hooks/useNicknameCheck/NICKNAME_ERROR_MESSAGE.ts
+++ b/src/hooks/useNicknameCheck/NICKNAME_ERROR_MESSAGE.ts
@@ -1,4 +1,0 @@
-export const NICKNAME_ERROR_MESSAGE = {
-  NICKNAME_INVALID: { message: "사용할 수 없는 단어가 포함되어 있어요", status: "warning" },
-  NICKNAME_DUPLICATE: { message: "이미 사용 중인 닉네임이에요", status: "warning" },
-} as const;


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호

## 작업 내용

- 어디서도 import되지 않는 죽은 상수 파일 CHECKBOX_CONFIG.ts, NICKNAME_ERROR_MESSAGE.ts를 삭제했습니다.
- Storybook 전역 preview에 NextIntlClientProvider(locale ko, ko.json 메시지) 데코레이터를 추가한다. useTranslations를 쓰는 컴포넌트의 스토리가 번역 컨텍스트 없이 렌더되던 문제를 고쳤습니다.

## 참고 사항

- 두 커밋 모두 i18n 인증 라우트 번역 작업(feat/i18n-en-auth) 중 발견한 이슈를 별도 브랜치로 분리한 것입니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거