### PR TITLE
feat: 채팅 페이지 영어 번역 추가

### DIFF
--- a/src/app/[locale]/(route)/chat/[postId]/_components/CHATROOM_CONST.ts
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/CHATROOM_CONST.ts
@@ -2,18 +2,16 @@ import { IconName } from "@/components";
 import { InfoButtonOptionValue } from "../_types/InfoButtonOptionValue";
 
 export const CHAT_CHIP_MODE = {
-  FIND: { style: "text-accent-foundItem bg-fill-accent-foundItem", text: "발견" },
-  LOST: { style: "text-accent-lostItem bg-fill-accent-lostItem", text: "분실" },
+  FIND: { style: "text-accent-foundItem bg-fill-accent-foundItem" },
+  LOST: { style: "text-accent-lostItem bg-fill-accent-lostItem" },
   FOUND_STATUS: {
     style: "bg-toast/70 text-white px-1 py-[2.5px]",
-    text: "찾았어요",
   },
 } as const;
 
 export type ChatChipMode = keyof typeof CHAT_CHIP_MODE;
 
 interface InfoOption {
-  label: string;
   value: InfoButtonOptionValue;
   textColor: "text-neutral-normal-default" | "text-system-warning";
   position: "first" | "last";
@@ -21,13 +19,11 @@ interface InfoOption {
 
 export const INFO_OPTIONS: InfoOption[] = [
   {
-    label: "차단, 신고하기",
     value: "report",
     textColor: "text-neutral-normal-default",
     position: "first",
   },
   {
-    label: "채팅방 나가기",
     value: "leave",
     textColor: "text-system-warning",
     position: "last",
@@ -53,10 +49,8 @@ export const CHAT_SENDER_STYLE = {
 export const EMPTY_MODE_STYLE = {
   lost: {
     iconName: "ChatLost" as IconName,
-    helpText: ["이 분실물을 주우셨나요?", "주인에게 먼저 연락해보세요."],
   },
   find: {
     iconName: "ChatFind" as IconName,
-    helpText: ["내 물건이 맞는지 확인해보세요.", "발견자에게 메시지를 보내세요."],
   },
 };

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatChip/ChatChip.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatChip/ChatChip.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils";
-import { CHAT_CHIP_MODE, ChatChipMode } from "../CHATROOM_CONST";
+import { ChatChipMode } from "../CHATROOM_CONST";
 import { ItemStatus, PostType } from "@/types";
+import useChatChipMode from "../../_hooks/useChatChipMode/useChatChipMode";
 
 const CHIP_BASE_CLASS = "shrink-0 rounded text-caption2-semibold flex-center";
 
@@ -10,9 +11,10 @@ interface ChatChipProps {
 }
 
 const ChatChip = ({ postMode, postStatus }: ChatChipProps) => {
+  const chatChipMode = useChatChipMode();
   const chipMode: ChatChipMode = postMode === "FOUND" ? "FIND" : "LOST";
-  const typeChipConfig = CHAT_CHIP_MODE[chipMode];
-  const foundStatusConfig = CHAT_CHIP_MODE.FOUND_STATUS;
+  const typeChipConfig = chatChipMode[chipMode];
+  const foundStatusConfig = chatChipMode.FOUND_STATUS;
 
   return (
     <>

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeader/ChatRoomHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Icon, ListItemImage } from "@/components";
 import ChatChip from "../ChatChip/ChatChip";
 import ChatRoomHeaderInfoButton from "../ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton";
@@ -21,6 +22,8 @@ interface ChatRoomHeaderProps {
 }
 
 const LinkWrapper = ({ deleted, children, href }: LinkWrapperProps) => {
+  const t = useTranslations("ChatRoomHeader");
+
   return (
     <>
       {deleted ? (
@@ -28,7 +31,7 @@ const LinkWrapper = ({ deleted, children, href }: LinkWrapperProps) => {
       ) : (
         <Link
           href={href}
-          aria-label="게시글 상세 페이지 이동"
+          aria-label={t("postLinkAriaLabel")}
           className="flex items-center gap-4 px-4"
         >
           {children}
@@ -41,6 +44,7 @@ const LinkWrapper = ({ deleted, children, href }: LinkWrapperProps) => {
 const NICK_NAME_STYLE = "text-body2-semibold text-layout-body-default";
 
 const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoomHeaderProps) => {
+  const t = useTranslations("ChatRoomHeader");
   if (!chatRoom) return null;
   const { address, postType, title, thumbnailUrl, postId, category, postStatus, deleted } =
     chatRoom.postInfo;
@@ -54,17 +58,17 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoom
           replace
           href="/chat"
           className="flex h-10 w-10 items-center"
-          aria-label="뒤로 가기 버튼"
+          aria-label={t("backAriaLabel")}
         >
           <Icon name="ArrowLeftSmall" size={18} className="text-neutral-normal-default" />
         </Link>
 
         {isOwnPostChatRoom || withdrawn ? (
-          <p className={NICK_NAME_STYLE}>{withdrawn ? "탈퇴한 회원이에요" : nickname}</p>
+          <p className={NICK_NAME_STYLE}>{withdrawn ? t("withdrawnUser") : nickname}</p>
         ) : (
           <Link
             href={`/user/${opponentUserId}`}
-            aria-label="상대방 프로필 이동"
+            aria-label={t("profileAriaLabel")}
             className={NICK_NAME_STYLE}
           >
             {nickname}
@@ -77,7 +81,7 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoom
       <LinkWrapper deleted={deleted} href={`/list/${postId}`}>
         <div className="shrink-0">
           <ListItemImage
-            alt="채팅방 게시글 썸네일"
+            alt={t("thumbnailAlt")}
             size={40}
             src={thumbnailUrl}
             category={category}
@@ -88,7 +92,7 @@ const ChatRoomHeader = ({ chatRoom, roomId, currentUserId, withdrawn }: ChatRoom
           <div className="flex items-center gap-1">
             <ChatChip postMode={postType} postStatus={postStatus} />
             <h2 className="truncate text-body1-semibold text-layout-header-default">
-              {deleted && !withdrawn ? `삭제됨 ${title}` : title}
+              {deleted && !withdrawn ? t("deletedTitle", { title }) : title}
             </h2>
           </div>
           <p className="min-h-4 text-caption1-medium text-layout-body-default">{address}</p>

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/ChatRoomHeaderInfoButton.tsx
@@ -3,11 +3,12 @@
 import { Icon, ReportModal } from "@/components";
 import { cn } from "@/utils";
 import { useState } from "react";
-import { INFO_OPTIONS } from "../CHATROOM_CONST";
 import { InfoButtonOptionValue } from "../../_types/InfoButtonOptionValue";
 import useLeaveChatRoom from "@/api/fetch/chatRoom/api/useLeaveChatRoom";
 import { useClickOutside } from "@/hooks";
 import ChatLeaveModal from "./_internal/ChatLeaveModal";
+import useInfoOptions from "../../_hooks/useInfoOptions/useInfoOptions";
+import { useTranslations } from "next-intl";
 
 const MenuItem = ({
   chatMenuOpen,
@@ -16,11 +17,12 @@ const MenuItem = ({
   chatMenuOpen: boolean;
   onOptionClick: (value: InfoButtonOptionValue) => void;
 }) => {
+  const infoOptions = useInfoOptions();
   if (!chatMenuOpen) return null;
 
   return (
     <ul className="absolute right-0 top-10 z-10 m-0 list-none p-0" role="menu">
-      {INFO_OPTIONS.map(({ value, label, textColor, position }) => {
+      {infoOptions.map(({ value, label, textColor, position }) => {
         return (
           <li key={value} role="menuitem">
             <button
@@ -43,6 +45,7 @@ const MenuItem = ({
 };
 
 const ChatRoomHeaderInfoButton = ({ roomId }: { roomId: number }) => {
+  const t = useTranslations("ChatRoomHeaderInfoButton");
   const [chatMenuOpen, setChatMenuOpen] = useState(false);
   const [leaveChatRoomModalOpen, setLeaveChatRoomModalOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
@@ -62,7 +65,7 @@ const ChatRoomHeaderInfoButton = ({ roomId }: { roomId: number }) => {
       <div ref={containerRef} className="relative">
         <button
           className="flex h-10 w-10 items-center justify-end"
-          aria-label="채팅방 메뉴 열기 버튼"
+          aria-label={t("menuAriaLabel")}
           type="button"
           onClick={() => setChatMenuOpen((prev) => !prev)}
         >

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/_internal/ChatLeaveModal.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomHeaderInfoButton/_internal/ChatLeaveModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import { ModalLayout } from "@/components";
 
@@ -14,16 +15,17 @@ const BUTTON_STYLE_CANCEL =
 const BUTTON_STYLE_CONFIRM = "bg-fill-brand-strong-default text-white";
 
 const ChatLeaveModal = ({ isOpen, onClose, onConfirm, onCancel }: ChatLeaveModalProps) => {
+  const t = useTranslations("ChatLeaveModal");
   const buttons = [
     {
       key: "cancel",
-      label: "아니요",
+      label: t("cancelLabel"),
       onClick: onCancel,
       style: BUTTON_STYLE_CANCEL,
     },
     {
       key: "confirm",
-      label: "네, 나갈래요",
+      label: t("confirmLabel"),
       onClick: onConfirm,
       style: BUTTON_STYLE_CONFIRM,
     },
@@ -38,9 +40,9 @@ const ChatLeaveModal = ({ isOpen, onClose, onConfirm, onCancel }: ChatLeaveModal
     >
       <div className="gap-4 flex-col-center">
         <div className="gap-1 text-center flex-col-center">
-          <p className="text-h3-semibold text-layout-header-default">채팅방을 나가시겠어요?</p>
+          <p className="text-h3-semibold text-layout-header-default">{t("title")}</p>
           <p className="whitespace-pre-line text-body2-regular text-layout-body-default">
-            {`채팅방을 나가면 채팅 목록 및 대화 내용이 삭제되고\n복구할 수 없어요. 채팅방에서 나가시겠어요?`}
+            {t("description")}
           </p>
         </div>
       </div>

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ChatImageBox/ChatImageBox.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ChatImageBox/ChatImageBox.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import { getImageLayout, getSpecialLayoutGroups } from "@/utils/getImageLayout/getImageLayout";
 import ChatImageButton from "../ChatImageButton/ChatImageButton";
@@ -17,6 +18,7 @@ const ChatImageBox = ({
   bubbleOrder: string;
   opponentNickname?: string;
 }) => {
+  const t = useTranslations("ChatImageBox");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
@@ -30,7 +32,7 @@ const ChatImageBox = ({
     setIsModalOpen(true);
   };
 
-  const uploader = bubbleOrder === "order-1" ? opponentNickname || "상대방" : "나";
+  const uploader = bubbleOrder === "order-1" ? opponentNickname || t("theyLabel") : t("youLabel");
 
   return (
     <>

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ChatImageButton/ChatImageButton.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ChatImageButton/ChatImageButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import Image from "next/image";
 
@@ -11,6 +12,8 @@ interface ChatImageButtonProps {
 }
 
 const ChatImageButton = ({ src, width, height, colSpan, index, onClick }: ChatImageButtonProps) => {
+  const t = useTranslations("ChatImageButton");
+
   return (
     <button
       type="button"
@@ -21,7 +24,7 @@ const ChatImageButton = ({ src, width, height, colSpan, index, onClick }: ChatIm
         src={src}
         width={width}
         height={height}
-        alt={`채팅 이미지 ${index + 1}`}
+        alt={t("imageAlt", { index: index + 1 })}
         className="object-cover"
         style={{ width: `${width}px`, height: `${height}px` }}
       />

--- a/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ExpandableMessageBubble/ExpandableMessageBubble.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/ChatRoomMain/_internal/ExpandableMessageBubble/ExpandableMessageBubble.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import { useEffect, useRef, useState } from "react";
 
@@ -14,6 +15,7 @@ const ExpandableMessageBubble = ({
   bubbleColor,
   bubbleOrder,
 }: ExpandableMessageBubbleProps) => {
+  const t = useTranslations("ExpandableMessageBubble");
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const contentRef = useRef<HTMLParagraphElement>(null);
@@ -56,7 +58,7 @@ const ExpandableMessageBubble = ({
           className="text-caption1-medium text-layout-body-default underline"
           onClick={() => setIsExpanded((prev) => !prev)}
         >
-          {isExpanded ? "숨기기" : "더보기"}
+          {isExpanded ? t("hideLabel") : t("showMoreLabel")}
         </button>
       ) : null}
     </div>

--- a/src/app/[locale]/(route)/chat/[postId]/_components/EmptyChatRoom/EmptyChatRoom.test.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/EmptyChatRoom/EmptyChatRoom.test.tsx
@@ -26,10 +26,11 @@ describe("EmptyChatRoom", () => {
   });
 
   it("postMode가 find일 때 올바른 도움말 텍스트가 렌더링됩니다", () => {
-    render(<EmptyChatRoom postMode="find" />);
+    const { container } = render(<EmptyChatRoom postMode="find" />);
 
-    expect(screen.getByText("내 물건이 맞는지 확인해보세요.")).toBeInTheDocument();
-    expect(screen.getByText("발견자에게 메시지를 보내세요.")).toBeInTheDocument();
+    const helpText = container.querySelector("p");
+    expect(helpText).toHaveTextContent("내 물건이 맞는지 확인해보세요.");
+    expect(helpText).toHaveTextContent("발견자에게 메시지를 보내세요.");
   });
 
   it("postMode가 lost일 때 ChatLost 아이콘이 렌더링됩니다", () => {
@@ -41,14 +42,15 @@ describe("EmptyChatRoom", () => {
   });
 
   it("postMode가 lost일 때 올바른 도움말 텍스트가 렌더링됩니다", () => {
-    render(<EmptyChatRoom postMode="lost" />);
+    const { container } = render(<EmptyChatRoom postMode="lost" />);
 
-    expect(screen.getByText("이 분실물을 주우셨나요?")).toBeInTheDocument();
-    expect(screen.getByText("주인에게 먼저 연락해보세요.")).toBeInTheDocument();
+    const helpText = container.querySelector("p");
+    expect(helpText).toHaveTextContent("이 분실물을 주우셨나요?");
+    expect(helpText).toHaveTextContent("주인에게 먼저 연락해보세요.");
   });
 
   it("find 모드일 때 모든 요소가 올바르게 렌더링됩니다", () => {
-    render(<EmptyChatRoom postMode="find" />);
+    const { container } = render(<EmptyChatRoom postMode="find" />);
 
     // 스크린 리더용 제목
     expect(screen.getByRole("heading", { name: "빈 채팅 안내 화면" })).toBeInTheDocument();
@@ -57,12 +59,13 @@ describe("EmptyChatRoom", () => {
     expect(screen.getByTestId("icon-ChatFind")).toBeInTheDocument();
 
     // 도움말 텍스트
-    expect(screen.getByText("내 물건이 맞는지 확인해보세요.")).toBeInTheDocument();
-    expect(screen.getByText("발견자에게 메시지를 보내세요.")).toBeInTheDocument();
+    const helpText = container.querySelector("p");
+    expect(helpText).toHaveTextContent("내 물건이 맞는지 확인해보세요.");
+    expect(helpText).toHaveTextContent("발견자에게 메시지를 보내세요.");
   });
 
   it("lost 모드일 때 모든 요소가 올바르게 렌더링됩니다", () => {
-    render(<EmptyChatRoom postMode="lost" />);
+    const { container } = render(<EmptyChatRoom postMode="lost" />);
 
     // 스크린 리더용 제목
     expect(screen.getByRole("heading", { name: "빈 채팅 안내 화면" })).toBeInTheDocument();
@@ -71,19 +74,18 @@ describe("EmptyChatRoom", () => {
     expect(screen.getByTestId("icon-ChatLost")).toBeInTheDocument();
 
     // 도움말 텍스트
-    expect(screen.getByText("이 분실물을 주우셨나요?")).toBeInTheDocument();
-    expect(screen.getByText("주인에게 먼저 연락해보세요.")).toBeInTheDocument();
+    const helpText = container.querySelector("p");
+    expect(helpText).toHaveTextContent("이 분실물을 주우셨나요?");
+    expect(helpText).toHaveTextContent("주인에게 먼저 연락해보세요.");
   });
 
-  it("도움말 텍스트가 여러 줄로 렌더링됩니다", () => {
-    render(<EmptyChatRoom postMode="find" />);
+  it("도움말 텍스트가 줄바꿈으로 렌더링됩니다", () => {
+    const { container } = render(<EmptyChatRoom postMode="find" />);
 
-    const helpTexts = screen.getAllByText(/./);
-    const findTexts = helpTexts.filter(
-      (text) =>
-        text.textContent === "내 물건이 맞는지 확인해보세요." ||
-        text.textContent === "발견자에게 메시지를 보내세요."
+    const helpText = container.querySelector("p");
+    expect(helpText).toHaveClass("whitespace-pre-line");
+    expect(helpText?.textContent).toBe(
+      "내 물건이 맞는지 확인해보세요.\n발견자에게 메시지를 보내세요."
     );
-    expect(findTexts.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/app/[locale]/(route)/chat/[postId]/_components/EmptyChatRoom/EmptyChatRoom.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/EmptyChatRoom/EmptyChatRoom.tsx
@@ -1,17 +1,19 @@
+import { useTranslations } from "next-intl";
 import { Icon } from "@/components";
-import { EMPTY_MODE_STYLE } from "../CHATROOM_CONST";
+import useEmptyModeStyle from "../../_hooks/useEmptyModeStyle/useEmptyModeStyle";
 
 const EmptyChatRoom = ({ postMode }: { postMode: "find" | "lost" }) => {
+  const t = useTranslations("EmptyChatRoom");
+  const emptyModeStyle = useEmptyModeStyle();
+
   return (
     <section className="flex-1 bg-flatGray-25 flex-center">
-      <h1 className="sr-only">빈 채팅 안내 화면</h1>
+      <h1 className="sr-only">{t("pageHeading")}</h1>
       <div className="gap-2 flex-col-center">
-        <Icon name={EMPTY_MODE_STYLE[postMode].iconName} size={80} />
-        <div className="select-none text-center text-body2-medium text-layout-body-default">
-          {EMPTY_MODE_STYLE[postMode].helpText.map((text, i) => (
-            <p key={i}>{text}</p>
-          ))}
-        </div>
+        <Icon name={emptyModeStyle[postMode].iconName} size={80} />
+        <p className="select-none whitespace-pre-line text-center text-body2-medium text-layout-body-default">
+          {emptyModeStyle[postMode].helpText}
+        </p>
       </div>
     </section>
   );

--- a/src/app/[locale]/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/InputChat/InputChat.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChangeEvent, TextareaHTMLAttributes, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { cn, textareaAutoResize, fileInputHandler, textareaSubmitKeyHandler } from "@/utils";
 import { Controller, RegisterOptions, useFormContext } from "react-hook-form";
 import { Icon } from "@/components";
@@ -27,6 +28,7 @@ const InputChat = ({
   withdrawn,
   ...props
 }: InputChatProps) => {
+  const t = useTranslations("InputChat");
   const { control, watch } = useFormContext();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [images, setImages] = useState<File[]>([]);
@@ -68,7 +70,7 @@ const InputChat = ({
                   "relative h-11 w-11 shrink-0 rounded-full bg-fill-neutral-strong-default",
                   withdrawn && "cursor-default"
                 )}
-                aria-label="이미지 첨부"
+                aria-label={t("imageAttachAriaLabel")}
                 role="button"
                 aria-disabled={withdrawn}
               >
@@ -106,7 +108,7 @@ const InputChat = ({
                   "max-h-[120px] min-h-11 min-w-0 flex-1 resize-none overflow-y-hidden rounded-[24px] px-4 py-[10px] text-body1-medium text-neutral-normal-placeholder bg-fill-neutral-strong-default focus:text-black disabled:text-neutral-strong-disabled",
                   field.value && "text-neutral-strong-focused"
                 )}
-                placeholder={withdrawn ? "상대방이 탈퇴한 회원입니다." : "메시지 보내기"}
+                placeholder={withdrawn ? t("placeholderWithdrawn") : t("placeholderDefault")}
                 disabled={disabled || withdrawn}
                 maxLength={255}
               />
@@ -115,7 +117,7 @@ const InputChat = ({
               <button
                 type="submit"
                 className="relative h-11 w-11 shrink-0 rounded-full transition-colors bg-fill-brand-normal-default hover:bg-fill-brand-normal-disabled active:bg-fill-brand-normal-default disabled:bg-fill-brand-normal-disabled"
-                aria-label="전송 버튼"
+                aria-label={t("sendAriaLabel")}
                 disabled={disabled || !field.value?.trim()}
               >
                 <Icon

--- a/src/app/[locale]/(route)/chat/[postId]/_components/InputChat/_internal/InputChatImageSection.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/_components/InputChat/_internal/InputChatImageSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Icon, ImageSelectButton } from "@/components";
 import useSendImage from "@/api/fetch/chatMessage/api/useSendImage";
 import {
@@ -19,6 +20,7 @@ const InputChatImageSection = ({
   imageState,
   onImageSendSuccess,
 }: InputChatImageSectionProps) => {
+  const t = useTranslations("InputChatImageSection");
   const { roomId, userId } = ids;
   const { images, setImages, selectedImages, setSelectedImages } = imageState;
   const { mutate: sendImage } = useSendImage(roomId, userId, {
@@ -29,19 +31,21 @@ const InputChatImageSection = ({
   return (
     <>
       <div className="mb-[20px] flex items-center justify-between px-[4px] pb-[12px]">
-        <button aria-label="사진 전송 취소 버튼" onClick={() => setImages([])}>
+        <button aria-label={t("cancelAriaLabel")} onClick={() => setImages([])}>
           <Icon name="XSecond" size={20} />
         </button>
 
         <button
-          aria-label="사진 전송 버튼"
+          aria-label={t("sendAriaLabel")}
           onClick={() =>
             handleSendImage(selectedImages, images, setImages, setSelectedImages, sendImage)
           }
           className="p-1 text-body1-medium text-brand-normal-default disabled:text-brand-normal-disabled"
           disabled={!selectedImages.length}
         >
-          {!selectedImages.length ? "사진 선택" : `사진 ${selectedImages.length}개 전송`}
+          {!selectedImages.length
+            ? t("selectLabel")
+            : t("sendCountLabel", { count: selectedImages.length })}
         </button>
       </div>
       <ImageSelectButton

--- a/src/app/[locale]/(route)/chat/[postId]/_hooks/useChatChipMode/useChatChipMode.ts
+++ b/src/app/[locale]/(route)/chat/[postId]/_hooks/useChatChipMode/useChatChipMode.ts
@@ -1,0 +1,14 @@
+import { useTranslations } from "next-intl";
+import { CHAT_CHIP_MODE } from "../../_components/CHATROOM_CONST";
+
+const useChatChipMode = () => {
+  const t = useTranslations("ChatChip");
+
+  return {
+    FIND: { ...CHAT_CHIP_MODE.FIND, text: t("findLabel") },
+    LOST: { ...CHAT_CHIP_MODE.LOST, text: t("lostLabel") },
+    FOUND_STATUS: { ...CHAT_CHIP_MODE.FOUND_STATUS, text: t("foundStatusLabel") },
+  } as const;
+};
+
+export default useChatChipMode;

--- a/src/app/[locale]/(route)/chat/[postId]/_hooks/useEmptyModeStyle/useEmptyModeStyle.ts
+++ b/src/app/[locale]/(route)/chat/[postId]/_hooks/useEmptyModeStyle/useEmptyModeStyle.ts
@@ -1,0 +1,13 @@
+import { useTranslations } from "next-intl";
+import { EMPTY_MODE_STYLE } from "../../_components/CHATROOM_CONST";
+
+const useEmptyModeStyle = () => {
+  const t = useTranslations("EmptyChatRoom");
+
+  return {
+    lost: { ...EMPTY_MODE_STYLE.lost, helpText: t("lostHelpText") },
+    find: { ...EMPTY_MODE_STYLE.find, helpText: t("findHelpText") },
+  } as const;
+};
+
+export default useEmptyModeStyle;

--- a/src/app/[locale]/(route)/chat/[postId]/_hooks/useHandleSendImage/useHandleSendImage.ts
+++ b/src/app/[locale]/(route)/chat/[postId]/_hooks/useHandleSendImage/useHandleSendImage.ts
@@ -1,42 +1,40 @@
-import { useCallback } from "react";
 import { Dispatch, SetStateAction } from "react";
+import { useTranslations } from "next-intl";
 import { useToast } from "@/context/ToastContext";
 import { resizeImage } from "@/utils";
 import { SelectedImage } from "@/types/SelectedImage";
 
 export const useHandleSendImage = () => {
+  const t = useTranslations("HandleSendImage");
   const { addToast } = useToast();
 
-  return useCallback(
-    async (
-      selectedImages: SelectedImage[],
-      images: File[],
-      setImages: Dispatch<SetStateAction<File[]>>,
-      setSelectedImages: Dispatch<SetStateAction<SelectedImage[]>>,
-      sendImage: (data: FormData) => void
-    ) => {
-      if (selectedImages.length === 0) return;
+  return async (
+    selectedImages: SelectedImage[],
+    images: File[],
+    setImages: Dispatch<SetStateAction<File[]>>,
+    setSelectedImages: Dispatch<SetStateAction<SelectedImage[]>>,
+    sendImage: (data: FormData) => void
+  ) => {
+    if (selectedImages.length === 0) return;
 
-      const sorted = [...selectedImages].sort((a, b) => a.order - b.order);
+    const sorted = [...selectedImages].sort((a, b) => a.order - b.order);
 
-      try {
-        const resizedImages = await Promise.all(
-          sorted.map((item) => resizeImage(images[item.index]))
-        );
+    try {
+      const resizedImages = await Promise.all(
+        sorted.map((item) => resizeImage(images[item.index]))
+      );
 
-        const formData = new FormData();
-        resizedImages.forEach((resizedFile) => {
-          formData.append("images", resizedFile);
-        });
+      const formData = new FormData();
+      resizedImages.forEach((resizedFile) => {
+        formData.append("images", resizedFile);
+      });
 
-        sendImage(formData);
+      sendImage(formData);
 
-        setImages([]);
-        setSelectedImages([]);
-      } catch {
-        addToast("이미지 처리 중 오류가 발생했습니다.", "error");
-      }
-    },
-    [addToast]
-  );
+      setImages([]);
+      setSelectedImages([]);
+    } catch {
+      addToast(t("imageErrorToast"), "error");
+    }
+  };
 };

--- a/src/app/[locale]/(route)/chat/[postId]/_hooks/useInfoOptions/useInfoOptions.ts
+++ b/src/app/[locale]/(route)/chat/[postId]/_hooks/useInfoOptions/useInfoOptions.ts
@@ -1,0 +1,10 @@
+import { useTranslations } from "next-intl";
+import { INFO_OPTIONS } from "../../_components/CHATROOM_CONST";
+
+const useInfoOptions = () => {
+  const t = useTranslations("ChatRoomHeaderInfoButton");
+
+  return INFO_OPTIONS.map((option) => ({ ...option, label: t(`${option.value}Label`) }));
+};
+
+export default useInfoOptions;

--- a/src/app/[locale]/(route)/chat/[postId]/layout.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/layout.tsx
@@ -1,11 +1,16 @@
 import { ReactNode } from "react";
+import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "채팅방 | 찾아줘! 채팅",
-  description: "찾아줘에서 진행 중인 채팅을 확인해보세요.",
-  other: { "page-type": "chat-detail" },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("ChatRoomLayout");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    other: { "page-type": "chat-detail" },
+  };
+}
 
 const layout = ({ children }: { children: ReactNode }) => {
   return children;

--- a/src/app/[locale]/(route)/chat/[postId]/page.tsx
+++ b/src/app/[locale]/(route)/chat/[postId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { ChatRoomHeader, EmptyChatRoom, ChatRoomMain, InputChat } from "./_components";
 import { FormProvider, useForm } from "react-hook-form";
 import { use, useCallback, useEffect, useState } from "react";
@@ -16,6 +17,7 @@ interface ChatFormValues {
 }
 
 const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
+  const t = useTranslations("ChatRoom");
   const { postId: postIdString } = use(params);
   const { addToast } = useToast();
   const postId = Number(postIdString);
@@ -31,7 +33,7 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
 
   useEffect(() => {
     if (withdrawn) {
-      addToast("알 수 없는 사용자이거나 탈퇴한 회원이에요", "warning");
+      addToast(t("withdrawnToast"), "warning");
     }
   }, [withdrawn, addToast]);
 
@@ -81,7 +83,7 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
         currentUserId={currentUserId}
         withdrawn={withdrawn}
       />
-      <h1 className="sr-only">채팅 상세 페이지</h1>
+      <h1 className="sr-only">{t("pageHeading")}</h1>
 
       <div className="flex min-h-0 flex-1 flex-col">
         {chatMessages?.length !== 0 && chatMessages ? (
@@ -102,7 +104,7 @@ const ChatRoom = ({ params }: { params: Promise<{ postId: string }> }) => {
           <form onSubmit={methods.handleSubmit(onSubmit)} className="px-4 pb-6 pt-3">
             <InputChat
               name="content"
-              aria-label="채팅 입력창"
+              aria-label={t("inputAriaLabel")}
               roomId={roomId}
               userId={userId}
               onImageSendSuccess={triggerScrollToBottom}

--- a/src/app/[locale]/(route)/chat/_components/CHATLIST_CONST.ts
+++ b/src/app/[locale]/(route)/chat/_components/CHATLIST_CONST.ts
@@ -1,29 +1,3 @@
-export const TYPE_OPTIONS = [
-  { label: "전체", value: "all" },
-  { label: "발견", value: "found" },
-  { label: "분실", value: "lost" },
-] as const;
+export const TYPE_OPTIONS = [{ value: "all" }, { value: "found" }, { value: "lost" }] as const;
 
-export const SORT_OPTIONS = [
-  { label: "최신순", value: "latest" },
-  { label: "오래된순", value: "oldest" },
-] as const;
-
-export const FilTER_DROPDOWN_OPTIONS = [
-  {
-    options: SORT_OPTIONS,
-    keyName: "sort",
-  },
-  {
-    options: TYPE_OPTIONS,
-    keyName: "type",
-  },
-] as const;
-
-export const SELECTED_TEXT = {
-  oldest: "오래된순",
-  latest: "최신순",
-  all: "발견/분실",
-  found: "발견",
-  lost: "분실",
-} as const;
+export const SORT_OPTIONS = [{ value: "latest" }, { value: "oldest" }] as const;

--- a/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { ChatRoom } from "@/api/fetch/chatRoom/types/ChatRoomResponse";
 import { ListItemImage, ProfileAvatar } from "@/components";
-import { formatCappedNumber, formatDate } from "@/utils";
+import { formatCappedNumber } from "@/utils";
+import { useFormatDate } from "@/hooks";
 
 interface ChatItemProps {
   chatRoom: ChatRoom;
@@ -10,6 +11,7 @@ interface ChatItemProps {
 
 const ChatItem = ({ chatRoom }: ChatItemProps) => {
   const t = useTranslations("ChatItem");
+  const formatDate = useFormatDate();
   const { lastMessageSentAt, lastMessage, unreadCount, messageType } = chatRoom;
   const { postId, address, thumbnailUrl, category } = chatRoom.postInfo;
   const { nickname, profileImageUrl, withdrawn } = chatRoom.contactUser;

--- a/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 import { ChatRoom } from "@/api/fetch/chatRoom/types/ChatRoomResponse";
 import { ListItemImage, ProfileAvatar } from "@/components";
 import { formatCappedNumber } from "@/utils";
-import { useFormatDate } from "@/hooks";
+import useFormatDate from "@/hooks/useFormatDate/useFormatDate";
 
 interface ChatItemProps {
   chatRoom: ChatRoom;

--- a/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ChatItem/ChatItem.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { ChatRoom } from "@/api/fetch/chatRoom/types/ChatRoomResponse";
 import { ListItemImage, ProfileAvatar } from "@/components";
 import { formatCappedNumber, formatDate } from "@/utils";
@@ -8,18 +9,19 @@ interface ChatItemProps {
 }
 
 const ChatItem = ({ chatRoom }: ChatItemProps) => {
+  const t = useTranslations("ChatItem");
   const { lastMessageSentAt, lastMessage, unreadCount, messageType } = chatRoom;
   const { postId, address, thumbnailUrl, category } = chatRoom.postInfo;
   const { nickname, profileImageUrl, withdrawn } = chatRoom.contactUser;
   const { roomId } = chatRoom;
 
   const lastMessageIsImage = lastMessageSentAt && messageType === "IMAGE";
-  const displayNickname = withdrawn ? "탈퇴한 회원" : nickname || "닉네임을 불러오지 못했습니다.";
-  const displayAddress = address || "위치 정보를 불러오지 못했습니다.";
-  const displayDate = formatDate(lastMessageSentAt || "시간 정보가 없습니다.");
+  const displayNickname = withdrawn ? t("withdrawnUser") : nickname || t("nicknameFallback");
+  const displayAddress = address || t("addressFallback");
+  const displayDate = formatDate(lastMessageSentAt || t("timeFallback"));
   const displayMessage = lastMessageIsImage
-    ? "사진"
-    : lastMessage || "메시지를 불러오지 못했습니다.";
+    ? t("imageMessage")
+    : lastMessage || t("messageFallback");
 
   return (
     <Link
@@ -45,7 +47,7 @@ const ChatItem = ({ chatRoom }: ChatItemProps) => {
           </span>
           {unreadCount > 0 && (
             <span className="rounded-full bg-flatGreen-500 px-[5.5px] py-[1.5px] text-caption2-semibold text-white flex-center">
-              <span className="sr-only">읽지 않은 메시지 </span>
+              <span className="sr-only">{t("unreadSrLabel")}</span>
               {formatCappedNumber(unreadCount)}
             </span>
           )}

--- a/src/app/[locale]/(route)/chat/_components/DefaultChatList/DefaultChatList.tsx
+++ b/src/app/[locale]/(route)/chat/_components/DefaultChatList/DefaultChatList.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Filter, EmptyState, LoadingState } from "@/components";
 import ChatItem from "../ChatItem/ChatItem";
 import { useSearchParams } from "next/navigation";
 import FilterDropdown from "../FilterDropdown/FilterDropdown";
-import { FilTER_DROPDOWN_OPTIONS } from "../CHATLIST_CONST";
+import useChatFilterOptions from "../../_hooks/useChatFilterOptions/useChatFilterOptions";
 import { useChatList } from "@/api/fetch/chatRoom";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll/useInfiniteScroll";
 
@@ -13,9 +14,11 @@ interface DefaultChatListProps {
 }
 
 const DefaultChatList = ({ searchUpdateQuery }: DefaultChatListProps) => {
+  const t = useTranslations("DefaultChatList");
+  const filterOptions = useChatFilterOptions();
   const searchParams = useSearchParams();
   const selectedRegion = searchParams.get("region");
-  const regionDisplayText = selectedRegion || "지역 선택";
+  const regionDisplayText = selectedRegion || t("regionPlaceholder");
   const {
     data: chatList,
     fetchNextPage,
@@ -41,19 +44,19 @@ const DefaultChatList = ({ searchUpdateQuery }: DefaultChatListProps) => {
         >
           {regionDisplayText}
         </Filter>
-        {FilTER_DROPDOWN_OPTIONS.map((option) => (
+        {filterOptions.map((option) => (
           <FilterDropdown key={option.keyName} {...option} searchUpdateQuery={searchUpdateQuery} />
         ))}
       </div>
 
-      {isLoading && <LoadingState title="채팅 목록 불러오는 중..." />}
+      {isLoading && <LoadingState title={t("loadingTitle")} />}
       {chatList?.length !== 0 ? (
         chatList?.map((chatRoom) => <ChatItem key={chatRoom.roomId} chatRoom={chatRoom} />)
       ) : (
         <EmptyState
           icon={{ iconName: "ChatListEmpty", iconSize: 90 }}
-          title="아직 채팅 내역이 없어요"
-          description="채팅이 시작되면 여기에 채팅 목록이 표기돼요."
+          title={t("emptyTitle")}
+          description={t("emptyDescription")}
         />
       )}
 

--- a/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.stories.tsx
@@ -1,6 +1,16 @@
 import { Meta, StoryObj } from "@storybook/nextjs";
 import FilterDropdown from "./FilterDropdown";
-import { SORT_OPTIONS, TYPE_OPTIONS } from "../CHATLIST_CONST";
+
+const SORT_OPTIONS = [
+  { value: "latest", label: "최신순" },
+  { value: "oldest", label: "오래된순" },
+];
+
+const TYPE_OPTIONS = [
+  { value: "all", label: "전체" },
+  { value: "found", label: "발견" },
+  { value: "lost", label: "분실" },
+];
 
 const meta: Meta<typeof FilterDropdown> = {
   title: "페이지/채팅 목록 페이지/FilterDropdown",

--- a/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.test.tsx
+++ b/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.test.tsx
@@ -2,8 +2,18 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import FilterDropdown from "./FilterDropdown";
-import { SORT_OPTIONS, TYPE_OPTIONS } from "../CHATLIST_CONST";
 import { useSearchParams } from "next/navigation";
+
+const SORT_OPTIONS = [
+  { value: "latest", label: "최신순" },
+  { value: "oldest", label: "오래된순" },
+];
+
+const TYPE_OPTIONS = [
+  { value: "all", label: "전체" },
+  { value: "found", label: "발견" },
+  { value: "lost", label: "분실" },
+];
 
 const mockSearchUpdateQuery = jest.fn();
 

--- a/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.tsx
+++ b/src/app/[locale]/(route)/chat/_components/FilterDropdown/FilterDropdown.tsx
@@ -4,7 +4,7 @@ import { Filter } from "@/components";
 import { useSearchParams } from "next/navigation";
 import { useState, useRef } from "react";
 import { createPortal } from "react-dom";
-import { SELECTED_TEXT } from "../CHATLIST_CONST";
+import useSelectedFilterText from "../../_hooks/useSelectedFilterText/useSelectedFilterText";
 import { cn } from "@/utils";
 import { usePopoverOutsideClose, usePopoverPosition } from "@/hooks";
 
@@ -24,6 +24,7 @@ const FilterDropdown = ({ options, keyName, searchUpdateQuery }: FilterDropdownP
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchParams = useSearchParams();
+  const selectedText = useSelectedFilterText();
   usePopoverOutsideClose(isOpen, containerRef, dropdownRef, () => setIsOpen(false));
   usePopoverPosition(isOpen, containerRef, dropdownRef);
 
@@ -34,7 +35,7 @@ const FilterDropdown = ({ options, keyName, searchUpdateQuery }: FilterDropdownP
   const isSelected = !isDefault;
   const effectiveKey = isDefault ? defaultKey : normalized;
   const displayText =
-    SELECTED_TEXT[effectiveKey as keyof typeof SELECTED_TEXT] ?? SELECTED_TEXT[defaultKey];
+    selectedText[effectiveKey as keyof typeof selectedText] ?? selectedText[defaultKey];
 
   const handleOptionClick = (value: string) => {
     searchUpdateQuery(keyName, value);

--- a/src/app/[locale]/(route)/chat/_components/ListSearch/ListSearch.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ListSearch/ListSearch.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { FieldValues, FormProvider, useForm } from "react-hook-form";
+import { useTranslations } from "next-intl";
 import RegionSearchView from "./_internal/RegionSearchView";
 import { InputSearch } from "@/components";
 import { useRouter } from "next/navigation";
 
 const ListSearch = () => {
+  const t = useTranslations("ListSearch");
   const router = useRouter();
   const methods = useForm({
     mode: "onChange",
@@ -23,12 +25,7 @@ const ListSearch = () => {
     <>
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)} className="px-5 py-[10px]">
-          <InputSearch
-            mode="RHF"
-            name="regionSearch"
-            placeholder="시/군/구를 입력해 주세요."
-            autoFocus
-          />
+          <InputSearch mode="RHF" name="regionSearch" placeholder={t("placeholder")} autoFocus />
         </form>
       </FormProvider>
 

--- a/src/app/[locale]/(route)/chat/_components/ListSearch/_internal/RegionSearchView.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ListSearch/_internal/RegionSearchView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useVWorldAddressSearch } from "@/hooks";
 import { highlightText } from "@/utils";
 import { VWorldAddressItem } from "@/types";
@@ -10,6 +11,7 @@ interface RegionSearchViewProps {
 }
 
 const RegionSearchView = ({ searchQuery }: RegionSearchViewProps) => {
+  const t = useTranslations("RegionSearchView");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -43,7 +45,7 @@ const RegionSearchView = ({ searchQuery }: RegionSearchViewProps) => {
 
       {isEmptyResult && (
         <p className="px-5 py-[10px] text-body1-medium text-layout-header-default">
-          검색 결과가 없습니다.
+          {t("emptyResult")}
         </p>
       )}
     </section>

--- a/src/app/[locale]/(route)/chat/_components/ListView/ListView.tsx
+++ b/src/app/[locale]/(route)/chat/_components/ListView/ListView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useTranslations } from "next-intl";
 import { DetailHeader, LoadingState } from "@/components";
 import { useSearchUpdateQueryString } from "@/hooks";
 import DefaultChatList from "../DefaultChatList/DefaultChatList";
@@ -9,10 +10,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Suspense } from "react";
 
 const ListSearch = dynamic(() => import("../ListSearch/ListSearch"), {
-  loading: () => <LoadingState title="지역 검색 불러오는 중..." />,
+  loading: () => {
+    const t = useTranslations("ListView");
+    return <LoadingState title={t("regionSearchLoading")} />;
+  },
 });
 
 const ListViewContent = () => {
+  const t = useTranslations("ListView");
   const { searchMode, searchUpdateQuery } = useSearchUpdateQueryString("push");
   const queryClient = useQueryClient();
 
@@ -24,9 +29,9 @@ const ListViewContent = () => {
 
   return (
     <>
-      <DetailHeader title={searchMode === "region" ? "지역 선택" : "채팅"} />
+      <DetailHeader title={searchMode === "region" ? t("regionTitle") : t("chatTitle")} />
 
-      <h1 className="sr-only">채팅 목록 페이지</h1>
+      <h1 className="sr-only">{t("pageHeading")}</h1>
       {searchMode === "default" ? (
         <DefaultChatList searchUpdateQuery={searchUpdateQuery} />
       ) : (

--- a/src/app/[locale]/(route)/chat/_hooks/useChatFilterOptions/useChatFilterOptions.ts
+++ b/src/app/[locale]/(route)/chat/_hooks/useChatFilterOptions/useChatFilterOptions.ts
@@ -1,0 +1,19 @@
+import { useTranslations } from "next-intl";
+import { SORT_OPTIONS, TYPE_OPTIONS } from "../../_components/CHATLIST_CONST";
+
+const useChatFilterOptions = () => {
+  const t = useTranslations("ChatFilterOptions");
+
+  return [
+    {
+      options: SORT_OPTIONS.map((option) => ({ ...option, label: t(`${option.value}Label`) })),
+      keyName: "sort",
+    },
+    {
+      options: TYPE_OPTIONS.map((option) => ({ ...option, label: t(`${option.value}Label`) })),
+      keyName: "type",
+    },
+  ] as const;
+};
+
+export default useChatFilterOptions;

--- a/src/app/[locale]/(route)/chat/_hooks/useSelectedFilterText/useSelectedFilterText.ts
+++ b/src/app/[locale]/(route)/chat/_hooks/useSelectedFilterText/useSelectedFilterText.ts
@@ -1,0 +1,15 @@
+import { useTranslations } from "next-intl";
+
+const useSelectedFilterText = () => {
+  const t = useTranslations("ChatFilterOptions");
+
+  return {
+    oldest: t("oldestLabel"),
+    latest: t("latestLabel"),
+    all: t("allSelectedLabel"),
+    found: t("foundLabel"),
+    lost: t("lostLabel"),
+  } as const;
+};
+
+export default useSelectedFilterText;

--- a/src/app/[locale]/(route)/chat/layout.tsx
+++ b/src/app/[locale]/(route)/chat/layout.tsx
@@ -1,12 +1,17 @@
 import { ReactNode } from "react";
+import { getTranslations } from "next-intl/server";
 import { ChatLayoutClient } from "./_components";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "채팅 목록",
-  description: "찾아줘에서 진행 중인 채팅을 확인해보세요.",
-  other: { "page-type": "chat-list" },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("ChatListLayout");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    other: { "page-type": "chat-list" },
+  };
+}
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return <ChatLayoutClient>{children}</ChatLayoutClient>;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -19,3 +19,4 @@ export { default as useErrorToast } from "./useErrorToast/useErrorToast";
 export { default as useFindPwSubmit } from "./useFindPwSubmit/useFindPwSubmit";
 export { useFilterSync } from "./useFilterSync/useFilterSync";
 export { useFindPwErrorMessage } from "./useFindPwErrorMessage/useFindPwErrorMessage";
+export { default as useFormatDate } from "./useFormatDate/useFormatDate";

--- a/src/hooks/useFormatDate/useFormatDate.ts
+++ b/src/hooks/useFormatDate/useFormatDate.ts
@@ -1,0 +1,16 @@
+import { useTranslations } from "next-intl";
+import formatDate from "@/utils/formatDate/formatDate/formatDate";
+
+const useFormatDate = () => {
+  const t = useTranslations("useFormatDate");
+
+  return (date: string) =>
+    formatDate(date, {
+      now: t("now"),
+      minutesAgo: (minutes) => t("minutesAgo", { count: minutes }),
+      hoursAgo: (hours) => t("hoursAgo", { count: hours }),
+      yesterday: t("yesterday"),
+    });
+};
+
+export default useFormatDate;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -917,5 +917,69 @@
   },
   "RegionSearchView": {
     "emptyResult": "No results found."
+  },
+  "ChatRoomLayout": {
+    "title": "Chat Room | Finditem Chat",
+    "description": "Check your ongoing chats on Finditem."
+  },
+  "ChatRoom": {
+    "withdrawnToast": "This user is unknown or has been deleted.",
+    "pageHeading": "Chat detail page",
+    "inputAriaLabel": "Chat message input"
+  },
+  "ChatRoomHeader": {
+    "backAriaLabel": "Go back",
+    "postLinkAriaLabel": "View post details",
+    "withdrawnUser": "This user has been deleted.",
+    "profileAriaLabel": "View user profile",
+    "thumbnailAlt": "Post thumbnail",
+    "deletedTitle": "[Deleted] {title}"
+  },
+  "ChatRoomHeaderInfoButton": {
+    "menuAriaLabel": "Open chat menu",
+    "reportLabel": "Block or report",
+    "leaveLabel": "Leave chat room"
+  },
+  "ChatLeaveModal": {
+    "cancelLabel": "No",
+    "confirmLabel": "Yes, leave",
+    "title": "Leave this chat room?",
+    "description": "Leaving will delete the chat and its messages,\nand this can't be undone. Are you sure you want to leave?"
+  },
+  "ChatChip": {
+    "findLabel": "Found",
+    "lostLabel": "Lost",
+    "foundStatusLabel": "Found"
+  },
+  "ChatImageBox": {
+    "youLabel": "You",
+    "theyLabel": "Them"
+  },
+  "ChatImageButton": {
+    "imageAlt": "Chat image {index}"
+  },
+  "ExpandableMessageBubble": {
+    "hideLabel": "Hide",
+    "showMoreLabel": "Show more"
+  },
+  "EmptyChatRoom": {
+    "pageHeading": "Empty chat screen",
+    "lostHelpText": "Did you find this lost item?\nReach out to the owner first.",
+    "findHelpText": "Check if this is your item.\nMessage the finder to reach out."
+  },
+  "InputChat": {
+    "imageAttachAriaLabel": "Attach image",
+    "placeholderWithdrawn": "This user has been deleted.",
+    "placeholderDefault": "Send a message",
+    "sendAriaLabel": "Send message"
+  },
+  "InputChatImageSection": {
+    "cancelAriaLabel": "Cancel photo",
+    "sendAriaLabel": "Send photo",
+    "selectLabel": "Select photos",
+    "sendCountLabel": "{count, plural, one {Send # photo} other {Send # photos}}"
+  },
+  "HandleSendImage": {
+    "imageErrorToast": "Something went wrong while processing the image."
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -878,5 +878,44 @@
   "LatestList": {
     "searchLabel": "Search {keyword}",
     "deleteLabel": "Delete recent search"
+  },
+  "ChatListLayout": {
+    "title": "Chat List",
+    "description": "Check your ongoing chats on Finditem."
+  },
+  "ListView": {
+    "regionSearchLoading": "Loading region search...",
+    "regionTitle": "Select region",
+    "chatTitle": "Chat",
+    "pageHeading": "Chat list page"
+  },
+  "DefaultChatList": {
+    "regionPlaceholder": "Select region",
+    "loadingTitle": "Loading chats...",
+    "emptyTitle": "No chats yet",
+    "emptyDescription": "Once a chat starts, it'll show up here."
+  },
+  "ChatFilterOptions": {
+    "allLabel": "All",
+    "foundLabel": "Found",
+    "lostLabel": "Lost",
+    "latestLabel": "Newest",
+    "oldestLabel": "Oldest",
+    "allSelectedLabel": "Found/Lost"
+  },
+  "ChatItem": {
+    "withdrawnUser": "Deleted user",
+    "nicknameFallback": "Couldn't load nickname.",
+    "addressFallback": "Couldn't load location.",
+    "timeFallback": "No time available.",
+    "imageMessage": "Photo",
+    "messageFallback": "Couldn't load message.",
+    "unreadSrLabel": "Unread messages "
+  },
+  "ListSearch": {
+    "placeholder": "Enter a city, county, or district."
+  },
+  "RegionSearchView": {
+    "emptyResult": "No results found."
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -912,6 +912,12 @@
     "messageFallback": "Couldn't load message.",
     "unreadSrLabel": "Unread messages "
   },
+  "useFormatDate": {
+    "now": "Just now",
+    "minutesAgo": "{count, plural, one {# minute ago} other {# minutes ago}}",
+    "hoursAgo": "{count, plural, one {# hour ago} other {# hours ago}}",
+    "yesterday": "Yesterday"
+  },
   "ListSearch": {
     "placeholder": "Enter a city, county, or district."
   },

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -912,6 +912,12 @@
     "messageFallback": "메시지를 불러오지 못했습니다.",
     "unreadSrLabel": "읽지 않은 메시지 "
   },
+  "useFormatDate": {
+    "now": "지금",
+    "minutesAgo": "{count}분 전",
+    "hoursAgo": "{count}시간 전",
+    "yesterday": "어제"
+  },
   "ListSearch": {
     "placeholder": "시/군/구를 입력해 주세요."
   },

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -878,5 +878,44 @@
   "LatestList": {
     "searchLabel": "{keyword} 검색",
     "deleteLabel": "최근 검색어 삭제"
+  },
+  "ChatListLayout": {
+    "title": "채팅 목록",
+    "description": "찾아줘에서 진행 중인 채팅을 확인해보세요."
+  },
+  "ListView": {
+    "regionSearchLoading": "지역 검색 불러오는 중...",
+    "regionTitle": "지역 선택",
+    "chatTitle": "채팅",
+    "pageHeading": "채팅 목록 페이지"
+  },
+  "DefaultChatList": {
+    "regionPlaceholder": "지역 선택",
+    "loadingTitle": "채팅 목록 불러오는 중...",
+    "emptyTitle": "아직 채팅 내역이 없어요",
+    "emptyDescription": "채팅이 시작되면 여기에 채팅 목록이 표기돼요."
+  },
+  "ChatFilterOptions": {
+    "allLabel": "전체",
+    "foundLabel": "발견",
+    "lostLabel": "분실",
+    "latestLabel": "최신순",
+    "oldestLabel": "오래된순",
+    "allSelectedLabel": "발견/분실"
+  },
+  "ChatItem": {
+    "withdrawnUser": "탈퇴한 회원",
+    "nicknameFallback": "닉네임을 불러오지 못했습니다.",
+    "addressFallback": "위치 정보를 불러오지 못했습니다.",
+    "timeFallback": "시간 정보가 없습니다.",
+    "imageMessage": "사진",
+    "messageFallback": "메시지를 불러오지 못했습니다.",
+    "unreadSrLabel": "읽지 않은 메시지 "
+  },
+  "ListSearch": {
+    "placeholder": "시/군/구를 입력해 주세요."
+  },
+  "RegionSearchView": {
+    "emptyResult": "검색 결과가 없습니다."
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -917,5 +917,69 @@
   },
   "RegionSearchView": {
     "emptyResult": "검색 결과가 없습니다."
+  },
+  "ChatRoomLayout": {
+    "title": "채팅방 | 찾아줘! 채팅",
+    "description": "찾아줘에서 진행 중인 채팅을 확인해보세요."
+  },
+  "ChatRoom": {
+    "withdrawnToast": "알 수 없는 사용자이거나 탈퇴한 회원이에요",
+    "pageHeading": "채팅 상세 페이지",
+    "inputAriaLabel": "채팅 입력창"
+  },
+  "ChatRoomHeader": {
+    "backAriaLabel": "뒤로 가기 버튼",
+    "postLinkAriaLabel": "게시글 상세 페이지 이동",
+    "withdrawnUser": "탈퇴한 회원이에요",
+    "profileAriaLabel": "상대방 프로필 이동",
+    "thumbnailAlt": "채팅방 게시글 썸네일",
+    "deletedTitle": "삭제됨 {title}"
+  },
+  "ChatRoomHeaderInfoButton": {
+    "menuAriaLabel": "채팅방 메뉴 열기 버튼",
+    "reportLabel": "차단, 신고하기",
+    "leaveLabel": "채팅방 나가기"
+  },
+  "ChatLeaveModal": {
+    "cancelLabel": "아니요",
+    "confirmLabel": "네, 나갈래요",
+    "title": "채팅방을 나가시겠어요?",
+    "description": "채팅방을 나가면 채팅 목록 및 대화 내용이 삭제되고\n복구할 수 없어요. 채팅방에서 나가시겠어요?"
+  },
+  "ChatChip": {
+    "findLabel": "발견",
+    "lostLabel": "분실",
+    "foundStatusLabel": "찾았어요"
+  },
+  "ChatImageBox": {
+    "youLabel": "나",
+    "theyLabel": "상대방"
+  },
+  "ChatImageButton": {
+    "imageAlt": "채팅 이미지 {index}"
+  },
+  "ExpandableMessageBubble": {
+    "hideLabel": "숨기기",
+    "showMoreLabel": "더보기"
+  },
+  "EmptyChatRoom": {
+    "pageHeading": "빈 채팅 안내 화면",
+    "lostHelpText": "이 분실물을 주우셨나요?\n주인에게 먼저 연락해보세요.",
+    "findHelpText": "내 물건이 맞는지 확인해보세요.\n발견자에게 메시지를 보내세요."
+  },
+  "InputChat": {
+    "imageAttachAriaLabel": "이미지 첨부",
+    "placeholderWithdrawn": "상대방이 탈퇴한 회원입니다.",
+    "placeholderDefault": "메시지 보내기",
+    "sendAriaLabel": "전송 버튼"
+  },
+  "InputChatImageSection": {
+    "cancelAriaLabel": "사진 전송 취소 버튼",
+    "sendAriaLabel": "사진 전송 버튼",
+    "selectLabel": "사진 선택",
+    "sendCountLabel": "사진 {count}개 전송"
+  },
+  "HandleSendImage": {
+    "imageErrorToast": "이미지 처리 중 오류가 발생했습니다."
   }
 }

--- a/src/utils/formatDate/formatDate/formatDate.ts
+++ b/src/utils/formatDate/formatDate/formatDate.ts
@@ -4,17 +4,33 @@ const MS_IN_MINUTE = 60 * 1000;
 const MS_IN_HOUR = 60 * MS_IN_MINUTE;
 const MS_IN_DAY = 24 * MS_IN_HOUR;
 
+export interface RelativeDateLabels {
+  now: string;
+  minutesAgo: (minutes: number) => string;
+  hoursAgo: (hours: number) => string;
+  yesterday: string;
+}
+
+const defaultLabels: RelativeDateLabels = {
+  now: "지금",
+  minutesAgo: (minutes) => `${minutes}분 전`,
+  hoursAgo: (hours) => `${hours}시간 전`,
+  yesterday: "어제",
+};
+
 /**
- * ISO 등 날짜 문자열을 현재 시각 기준 상대/절대 한국어형 라벨로 만듭니다.
+ * ISO 등 날짜 문자열을 현재 시각 기준 상대/절대 라벨로 만듭니다.
  *
  * @remarks
- * - `지금` / `N분 전` / `N시간 전` / `어제` / `YYYY.MM.DD` 중 하나를 골라 반환합니다. (임계값은 `MS_IN_MINUTE`, `MS_IN_HOUR`, `MS_IN_DAY` 기준)
+ * - `지금`(now) / `N분 전`(minutesAgo) / `N시간 전`(hoursAgo) / `어제`(yesterday) / `YYYY.MM.DD` 중 하나를 골라 반환합니다. (임계값은 `MS_IN_MINUTE`, `MS_IN_HOUR`, `MS_IN_DAY` 기준)
+ * - `labels`를 넘기지 않으면 기존 한국어 라벨을 그대로 사용합니다. 다국어가 필요한 화면은 `useFormatDate` 훅을 사용하세요.
  * - 미래 시각이면 상대 대신 `YYYY.MM.DD`로 고정해 표시합니다.
  * - 2일 이상 지난 날짜는 `YYYY.MM.DD`입니다. (`buildDateString` 사용)
  * - 파싱 실패 시 빈 문자열입니다.
  * - `new Date()`로 “지금”을 잡으므로 테스트에서는 `jest.setSystemTime` 등으로 기준 시각을 고정하는 것이 좋습니다.
  *
  * @param date - `parseDateString`에 맡길 수 있는 날짜 문자열
+ * @param labels - 상대 시간 라벨 (미지정 시 한국어 기본값)
  *
  * @returns 상대/절대 라벨 또는 빈 문자열
  *
@@ -29,7 +45,7 @@ const MS_IN_DAY = 24 * MS_IN_HOUR;
  * ```
  */
 
-const formatDate = (date: string) => {
+const formatDate = (date: string, labels: RelativeDateLabels = defaultLabels) => {
   const targetDate = parseDateString(date);
   if (!targetDate) {
     return "";
@@ -43,22 +59,22 @@ const formatDate = (date: string) => {
   }
 
   if (diffMs < MS_IN_MINUTE) {
-    return "지금";
+    return labels.now;
   }
 
   if (diffMs < MS_IN_HOUR) {
     const minutesAgo = Math.max(1, Math.floor(diffMs / MS_IN_MINUTE));
-    return `${minutesAgo}분 전`;
+    return labels.minutesAgo(minutesAgo);
   }
 
   if (diffMs < MS_IN_DAY) {
     const hoursAgo = Math.floor(diffMs / MS_IN_HOUR);
-    return `${hoursAgo}시간 전`;
+    return labels.hoursAgo(hoursAgo);
   }
 
   const diffDays = Math.floor(diffMs / MS_IN_DAY);
   if (diffDays === 1) {
-    return "어제";
+    return labels.yesterday;
   }
 
   return buildDateString(targetDate);


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호

## 작업 내용

- 채팅 목록/채팅방 라우트 전반에서 하드코딩된 한국어 문구를 next-intl 번역 훅으로 분리했습니다.
- CHATLIST_CONST.ts/CHATROOM_CONST.ts의 데이터 상수에서 번역 대상 라벨·텍스트를 제거하고 이를 채워주는 훅 5개를 새로 추가했습니다(useChatFilterOptions, useSelectedFilterText, useChatChipMode, useInfoOptions, useEmptyModeStyle).
- chat/layout.tsx, chat/[postId]/layout.tsx의 metadata를 getTranslations 패턴으로 전환했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거