### PR TITLE
feat: 알림 페이지 영어 번역 추가

### DIFF
--- a/src/app/[locale]/(route)/alert/_components/ALERT_CONST.ts
+++ b/src/app/[locale]/(route)/alert/_components/ALERT_CONST.ts
@@ -1,13 +1,13 @@
 import { NotificationType, ReferenceType } from "@/api/fetch/notification";
 
 export const ALERT_CATEGORIES = [
-  { key: "all", label: "전체" },
-  { key: "category", label: "카테고리 키워드" },
-  { key: "chat", label: "채팅" },
-  { key: "comment", label: "댓글" },
-  { key: "notice", label: "공지사항" },
-  { key: "inquiry_reply", label: "문의" },
-  { key: "report_result", label: "신고" },
+  { key: "all" },
+  { key: "category" },
+  { key: "chat" },
+  { key: "comment" },
+  { key: "notice" },
+  { key: "inquiry_reply" },
+  { key: "report_result" },
 ] as const;
 
 export const ALERT_ROW_BG = {

--- a/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.test.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.test.tsx
@@ -2,16 +2,14 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import AlertCategory from "./AlertCategory";
+import { ALERT_CATEGORIES as ALERT_CATEGORY_KEYS } from "../ALERT_CONST";
+import koMessages from "@/messages/ko.json";
 
-const ALERT_CATEGORIES = [
-  { key: "all", label: "전체" },
-  { key: "category", label: "카테고리 키워드" },
-  { key: "chat", label: "채팅" },
-  { key: "comment", label: "댓글" },
-  { key: "notice", label: "공지사항" },
-  { key: "inquiry_reply", label: "문의" },
-  { key: "report_result", label: "신고" },
-];
+const ALERT_CATEGORIES = ALERT_CATEGORY_KEYS.map((category) => ({
+  ...category,
+  label:
+    koMessages.AlertCategories[`${category.key}Label` as keyof typeof koMessages.AlertCategories],
+}));
 
 const mockReplace = jest.fn();
 const mockGet = jest.fn();

--- a/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.test.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.test.tsx
@@ -1,8 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ALERT_CATEGORIES } from "../ALERT_CONST";
 import AlertCategory from "./AlertCategory";
+
+const ALERT_CATEGORIES = [
+  { key: "all", label: "전체" },
+  { key: "category", label: "카테고리 키워드" },
+  { key: "chat", label: "채팅" },
+  { key: "comment", label: "댓글" },
+  { key: "notice", label: "공지사항" },
+  { key: "inquiry_reply", label: "문의" },
+  { key: "report_result", label: "신고" },
+];
 
 const mockReplace = jest.fn();
 const mockGet = jest.fn();

--- a/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertCategory/AlertCategory.tsx
@@ -2,19 +2,20 @@
 
 import { Filter } from "@/components";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ALERT_CATEGORIES } from "../ALERT_CONST";
+import useAlertCategories from "../../_hooks/useAlertCategories/useAlertCategories";
 import { AlertCategoryKey } from "../../_types/alertKeyType";
 
 const AlertCategory = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const alertCategories = useAlertCategories();
   const selectedCategory = (searchParams.get("category") as AlertCategoryKey) || "all";
 
   const handleCategoryClick = (key: AlertCategoryKey) => router.replace(`/alert?category=${key}`);
 
   return (
     <div className="flex gap-2 px-5 py-[14px] no-scrollbar">
-      {ALERT_CATEGORIES.map((category) => (
+      {alertCategories.map((category) => (
         <Filter
           key={category.key}
           ariaLabel={category.label}

--- a/src/app/[locale]/(route)/alert/_components/AlertDetailHeader/AlertDetailHeader.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertDetailHeader/AlertDetailHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useNotificationList } from "@/api/fetch/notification";
 import { DetailHeader, HeaderDelete, HeaderSetting } from "@/components";
 import { useRouter } from "next/navigation";
@@ -11,13 +12,14 @@ const AlertDetailHeader = ({
   isDeleteMode: boolean;
   setIsDeleteMode: (isDeleteMode: boolean) => void;
 }) => {
+  const t = useTranslations("AlertDetailHeader");
   const router = useRouter();
   const { data: notifications, isPending } = useNotificationList();
   const isDeleteDisabled = isPending || (notifications?.length ?? 0) === 0;
 
   return (
     <>
-      <DetailHeader title="알림">
+      <DetailHeader title={t("title")}>
         <HeaderDelete
           isDeleteMode={isDeleteMode}
           setIsDeleteMode={setIsDeleteMode}
@@ -25,7 +27,7 @@ const AlertDetailHeader = ({
         />
         <HeaderSetting onClick={() => router.push("/mypage/notifications")} />
       </DetailHeader>
-      <h1 className="sr-only">알림 페이지</h1>
+      <h1 className="sr-only">{t("pageHeading")}</h1>
     </>
   );
 };

--- a/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertDeleteModal/AlertDeleteModal.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertDeleteModal/AlertDeleteModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import { ModalLayout } from "@/components";
 
@@ -21,16 +22,17 @@ const AlertDeleteModal = ({
   onConfirm,
   onCancel,
 }: AlertDeleteModalProps) => {
+  const t = useTranslations("AlertDeleteModal");
   const buttons = [
     {
       key: "cancel",
-      label: "아니요",
+      label: t("cancelLabel"),
       onClick: onCancel,
       style: BUTTON_STYLE_CANCEL,
     },
     {
       key: "confirm",
-      label: "삭제하기",
+      label: t("confirmLabel"),
       onClick: onConfirm,
       style: BUTTON_STYLE_CONFIRM,
     },
@@ -40,12 +42,8 @@ const AlertDeleteModal = ({
     <ModalLayout isOpen={isOpen} onClose={onClose} className={cn("gap-6 p-6 flex-col-center")}>
       <div className="gap-4 flex-col-center">
         <div className="gap-1 text-center flex-col-center">
-          <div className="text-h3-semibold text-layout-header-default">
-            정말로 알림을 삭제하시겠어요?
-          </div>
-          <div className="text-body2-regular text-layout-body-default">
-            삭제한 알림은 복구할 수 없습니다.
-          </div>
+          <div className="text-h3-semibold text-layout-header-default">{t("title")}</div>
+          <div className="text-body2-regular text-layout-body-default">{t("description")}</div>
         </div>
       </div>
 

--- a/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertDeleteSection/AlertDeleteSection.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertDeleteSection/AlertDeleteSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { DeleteTarget } from "@/app/[locale]/(route)/alert/_types/DeleteTargetType";
 import { Button } from "@/components";
 
@@ -14,6 +15,7 @@ const AlertDeleteSection = ({
   setIsDeleteModalOpen,
   setDeleteTarget,
 }: AlertDeleteSectionProps) => {
+  const t = useTranslations("AlertDeleteSection");
   const handleDeleteAll = () => {
     setDeleteTarget("all");
     setIsDeleteModalOpen(true);
@@ -30,7 +32,7 @@ const AlertDeleteSection = ({
             className="w-[116px] text-system-warning"
             onClick={handleDeleteAll}
           >
-            전체 삭제
+            {t("deleteAllLabel")}
           </Button>
           <Button
             size="big"
@@ -38,7 +40,7 @@ const AlertDeleteSection = ({
             className="flex-1"
             onClick={() => setIsDeleteModalOpen(true)}
           >
-            선택 삭제
+            {t("deleteSelectedLabel")}
           </Button>
         </div>
       )}

--- a/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import {
   NotificationListItem,
   useNotificationList,
@@ -26,6 +27,7 @@ const AlertItem = ({
   selectedNotifications,
   setSelectedNotifications,
 }: AlertItemProps) => {
+  const t = useTranslations("AlertList");
   const router = useRouter();
   const {
     notificationId,
@@ -66,9 +68,9 @@ const AlertItem = ({
       aria-label={
         isDeleteMode
           ? isSelected
-            ? "선택된 알림, 탭하면 선택 해제"
-            : "알림 선택"
-          : "알림 확인, 외부 페이지 이동"
+            ? t("selectedAriaLabel")
+            : t("selectAriaLabel")
+          : t("viewAriaLabel")
       }
       className={cn(
         "flex min-h-[86px] w-full items-start gap-3 border-b border-divider-default p-5 text-left transition-colors",
@@ -128,6 +130,7 @@ const AlertList = ({
   selectedNotifications,
   setSelectedNotifications,
 }: AlertListProps) => {
+  const t = useTranslations("AlertList");
   const {
     data: notifications,
     fetchNextPage,
@@ -145,8 +148,8 @@ const AlertList = ({
     return (
       <EmptyState
         icon={{ iconName: "AlertBell", iconSize: 70 }}
-        title="아직 새 소식이 없어요"
-        description={`주변을 계속 살펴보고 있어요.\n새로운 알림이 생기면 바로 알려드릴게요.`}
+        title={t("emptyTitle")}
+        description={t("emptyDescription")}
       />
     );
   }

--- a/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
+++ b/src/app/[locale]/(route)/alert/_components/AlertView/_internal/AlertList/AlertList.tsx
@@ -108,7 +108,12 @@ const AlertItem = ({
             ))}
           </div>
           <span className="shrink-0 text-caption1-regular text-neutral-normal-placeholder">
-            {formatDate(createdAt)}
+            {formatDate(createdAt, {
+              now: t("now"),
+              minutesAgo: (count) => t("minutesAgo", { count }),
+              hoursAgo: (count) => t("hoursAgo", { count }),
+              yesterday: t("yesterday"),
+            })}
           </span>
         </div>
         <span className="min-w-0 truncate text-body2-regular text-neutral-strong-default">

--- a/src/app/[locale]/(route)/alert/_hooks/useAlertCategories/useAlertCategories.ts
+++ b/src/app/[locale]/(route)/alert/_hooks/useAlertCategories/useAlertCategories.ts
@@ -1,0 +1,10 @@
+import { useTranslations } from "next-intl";
+import { ALERT_CATEGORIES } from "../../_components/ALERT_CONST";
+
+const useAlertCategories = () => {
+  const t = useTranslations("AlertCategories");
+
+  return ALERT_CATEGORIES.map((category) => ({ ...category, label: t(`${category.key}Label`) }));
+};
+
+export default useAlertCategories;

--- a/src/app/[locale]/(route)/alert/layout.tsx
+++ b/src/app/[locale]/(route)/alert/layout.tsx
@@ -1,11 +1,16 @@
 import { ReactNode } from "react";
+import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "알림",
-  description: "찾아줘에서 나에게 온 알림을 확인해보세요.",
-  other: { "page-type": "alert" },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("AlertLayout");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    other: { "page-type": "alert" },
+  };
+}
 
 const layout = ({ children }: { children: ReactNode }) => {
   return <div className="h-f-base">{children}</div>;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -911,6 +911,10 @@
     "selectAriaLabel": "Select notification",
     "viewAriaLabel": "View notification and go to page",
     "emptyTitle": "No news yet",
-    "emptyDescription": "We're keeping an eye out nearby.\nWe'll let you know as soon as something comes up."
+    "emptyDescription": "We're keeping an eye out nearby.\nWe'll let you know as soon as something comes up.",
+    "now": "Just now",
+    "minutesAgo": "{count, plural, one {# minute ago} other {# minutes ago}}",
+    "hoursAgo": "{count, plural, one {# hour ago} other {# hours ago}}",
+    "yesterday": "Yesterday"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -878,5 +878,39 @@
   "LatestList": {
     "searchLabel": "Search {keyword}",
     "deleteLabel": "Delete recent search"
+  },
+  "AlertLayout": {
+    "title": "Notifications",
+    "description": "Check your notifications on Finditem."
+  },
+  "AlertDetailHeader": {
+    "title": "Notifications",
+    "pageHeading": "Notifications page"
+  },
+  "AlertCategories": {
+    "allLabel": "All",
+    "categoryLabel": "Category keywords",
+    "chatLabel": "Chat",
+    "commentLabel": "Comments",
+    "noticeLabel": "Notices",
+    "inquiry_replyLabel": "Inquiries",
+    "report_resultLabel": "Reports"
+  },
+  "AlertDeleteModal": {
+    "cancelLabel": "No",
+    "confirmLabel": "Delete",
+    "title": "Delete these notifications?",
+    "description": "Deleted notifications can't be recovered."
+  },
+  "AlertDeleteSection": {
+    "deleteAllLabel": "Delete all",
+    "deleteSelectedLabel": "Delete selected"
+  },
+  "AlertList": {
+    "selectedAriaLabel": "Selected notification, tap to deselect",
+    "selectAriaLabel": "Select notification",
+    "viewAriaLabel": "View notification and go to page",
+    "emptyTitle": "No news yet",
+    "emptyDescription": "We're keeping an eye out nearby.\nWe'll let you know as soon as something comes up."
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -878,5 +878,39 @@
   "LatestList": {
     "searchLabel": "{keyword} 검색",
     "deleteLabel": "최근 검색어 삭제"
+  },
+  "AlertLayout": {
+    "title": "알림",
+    "description": "찾아줘에서 나에게 온 알림을 확인해보세요."
+  },
+  "AlertDetailHeader": {
+    "title": "알림",
+    "pageHeading": "알림 페이지"
+  },
+  "AlertCategories": {
+    "allLabel": "전체",
+    "categoryLabel": "카테고리 키워드",
+    "chatLabel": "채팅",
+    "commentLabel": "댓글",
+    "noticeLabel": "공지사항",
+    "inquiry_replyLabel": "문의",
+    "report_resultLabel": "신고"
+  },
+  "AlertDeleteModal": {
+    "cancelLabel": "아니요",
+    "confirmLabel": "삭제하기",
+    "title": "정말로 알림을 삭제하시겠어요?",
+    "description": "삭제한 알림은 복구할 수 없습니다."
+  },
+  "AlertDeleteSection": {
+    "deleteAllLabel": "전체 삭제",
+    "deleteSelectedLabel": "선택 삭제"
+  },
+  "AlertList": {
+    "selectedAriaLabel": "선택된 알림, 탭하면 선택 해제",
+    "selectAriaLabel": "알림 선택",
+    "viewAriaLabel": "알림 확인, 외부 페이지 이동",
+    "emptyTitle": "아직 새 소식이 없어요",
+    "emptyDescription": "주변을 계속 살펴보고 있어요.\n새로운 알림이 생기면 바로 알려드릴게요."
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -911,6 +911,10 @@
     "selectAriaLabel": "알림 선택",
     "viewAriaLabel": "알림 확인, 외부 페이지 이동",
     "emptyTitle": "아직 새 소식이 없어요",
-    "emptyDescription": "주변을 계속 살펴보고 있어요.\n새로운 알림이 생기면 바로 알려드릴게요."
+    "emptyDescription": "주변을 계속 살펴보고 있어요.\n새로운 알림이 생기면 바로 알려드릴게요.",
+    "now": "지금",
+    "minutesAgo": "{count}분 전",
+    "hoursAgo": "{count}시간 전",
+    "yesterday": "어제"
   }
 }

--- a/src/utils/formatDate/formatDate/formatDate.ts
+++ b/src/utils/formatDate/formatDate/formatDate.ts
@@ -5,7 +5,7 @@ const MS_IN_HOUR = 60 * MS_IN_MINUTE;
 const MS_IN_DAY = 24 * MS_IN_HOUR;
 
 /**
- * ISO 등 날짜 문자열을 현재 시각 기준 상대/절대 한국어형 라벨로 만듭니다.
+ * ISO 등 날짜 문자열을 현재 시각 기준 상대/절대 라벨로 만듭니다.
  *
  * @remarks
  * - `지금` / `N분 전` / `N시간 전` / `어제` / `YYYY.MM.DD` 중 하나를 골라 반환합니다. (임계값은 `MS_IN_MINUTE`, `MS_IN_HOUR`, `MS_IN_DAY` 기준)
@@ -13,8 +13,10 @@ const MS_IN_DAY = 24 * MS_IN_HOUR;
  * - 2일 이상 지난 날짜는 `YYYY.MM.DD`입니다. (`buildDateString` 사용)
  * - 파싱 실패 시 빈 문자열입니다.
  * - `new Date()`로 “지금”을 잡으므로 테스트에서는 `jest.setSystemTime` 등으로 기준 시각을 고정하는 것이 좋습니다.
+ * - `messages`를 넘기지 않으면 기존과 동일하게 한국어 문구를 반환합니다. 로케일 대응이 필요한 화면에서는 `useTranslations`로 얻은 문구를 넘깁니다.
  *
  * @param date - `parseDateString`에 맡길 수 있는 날짜 문자열
+ * @param messages - 상대 시간 문구를 로케일에 맞게 대체할 때 전달 (미전달 시 한국어 기본값 사용)
  *
  * @returns 상대/절대 라벨 또는 빈 문자열
  *
@@ -26,10 +28,23 @@ const MS_IN_DAY = 24 * MS_IN_HOUR;
  * ```ts
  * formatDate(new Date().toISOString());
  * formatDate("2025-02-08T12:00:00");
+ * formatDate(item.createdAt, {
+ *   now: t("now"),
+ *   minutesAgo: (count) => t("minutesAgo", { count }),
+ *   hoursAgo: (count) => t("hoursAgo", { count }),
+ *   yesterday: t("yesterday"),
+ * });
  * ```
  */
 
-const formatDate = (date: string) => {
+export interface FormatDateMessages {
+  now: string;
+  minutesAgo: (count: number) => string;
+  hoursAgo: (count: number) => string;
+  yesterday: string;
+}
+
+const formatDate = (date: string, messages?: FormatDateMessages) => {
   const targetDate = parseDateString(date);
   if (!targetDate) {
     return "";
@@ -43,22 +58,22 @@ const formatDate = (date: string) => {
   }
 
   if (diffMs < MS_IN_MINUTE) {
-    return "지금";
+    return messages ? messages.now : "지금";
   }
 
   if (diffMs < MS_IN_HOUR) {
     const minutesAgo = Math.max(1, Math.floor(diffMs / MS_IN_MINUTE));
-    return `${minutesAgo}분 전`;
+    return messages ? messages.minutesAgo(minutesAgo) : `${minutesAgo}분 전`;
   }
 
   if (diffMs < MS_IN_DAY) {
     const hoursAgo = Math.floor(diffMs / MS_IN_HOUR);
-    return `${hoursAgo}시간 전`;
+    return messages ? messages.hoursAgo(hoursAgo) : `${hoursAgo}시간 전`;
   }
 
   const diffDays = Math.floor(diffMs / MS_IN_DAY);
   if (diffDays === 1) {
-    return "어제";
+    return messages ? messages.yesterday : "어제";
   }
 
   return buildDateString(targetDate);


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호

## 작업 내용

- 알림(alert) 라우트 전반에서 하드코딩된 한국어 문구를 next-intl 번역 훅으로 분리했습니다.
- ALERT_CONST.ts의 ALERT_CATEGORIES 데이터 배열에서 label을 제거하고 이를 채워주는 useAlertCategories 훅을 새로 추가했습니다.
- alert/layout.tsx의 metadata를 getTranslations 패턴으로 전환했습니다.
- 알림 삭제 모달/버튼, 알림 목록 아이템의 aria-label, 빈 상태 문구 등을 번역했습니다.

## 참고 사항

- alertTitleSegments.ts의 하이라이트 문구 상수는 백엔드가 내려주는 알림 제목(title) 원문과 정확히 일치해야 하이라이트 매칭이 동작하는 데이터 매칭용 문자열이라 번역 대상에서 제외했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거