### PR TITLE
feat : 애플 로그인 기능 및 테스트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY=your_kakao_javascript_key
 NEXT_PUBLIC_KAKAO_REST_API_KEY=your_kakao_rest_api_key
 NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:3000/auth/kakao/callback
 
+# Social Login - Apple
+NEXT_PUBLIC_APPLE_CLIENT_ID=your_apple_services_id
+NEXT_PUBLIC_APPLE_REDIRECT_URI=your_public_https_callback_url
+
 # External Services
 VWORLD_API_KEY=your_vworld_api_key
 PUBLIC_DATA_PORTAL_API_KEY=your_public_data_portal_api_key

--- a/src/api/fetch/auth/api/useApiAppleLogin.ts
+++ b/src/api/fetch/auth/api/useApiAppleLogin.ts
@@ -1,0 +1,10 @@
+import { AppleLoginResponseType } from "../types/AppleLoginResponseType";
+import { useApiSocialLogin } from "./useApiSocialLogin";
+
+interface AppleRequestType {
+  code: string;
+  environment: string;
+}
+
+export const useApiAppleLogin = () =>
+  useApiSocialLogin<AppleRequestType, AppleLoginResponseType>("apple");

--- a/src/api/fetch/auth/api/useApiKakaoLogin.ts
+++ b/src/api/fetch/auth/api/useApiKakaoLogin.ts
@@ -1,10 +1,5 @@
-import useAppMutation from "@/api/_base/query/useAppMutation";
-import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
-import { useToast } from "@/context/ToastContext";
-import { useRouter } from "next/navigation";
-import { AUTH_LOGIN_SUCCESS_EVENT } from "@/constants";
 import { KakaoLoginResponseType } from "../types/KakaoLoginResponseType";
-import { AxiosError } from "axios";
+import { useApiSocialLogin } from "./useApiSocialLogin";
 
 interface KakaoRequestType {
   code: string;
@@ -15,30 +10,5 @@ interface KakaoRequestType {
   marketingConsent?: boolean;
 }
 
-export const useApiKakaoLogin = () => {
-  const router = useRouter();
-
-  const { addToast } = useToast();
-
-  return useAppMutation<
-    KakaoRequestType,
-    KakaoLoginResponseType,
-    AxiosError<ApiBaseResponseType<null>>
-  >("auth", "/auth/kakao", "post", {
-    onSuccess: () => {
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new CustomEvent(AUTH_LOGIN_SUCCESS_EVENT));
-      }
-    },
-    onError: (error) => {
-      if (error.response?.data.code === "AUTH400-KAKAO_CODE_INVALID")
-        addToast("카카오 인증코드가 유효하지 않거나 이미 사용되었어요", "warning");
-      else if (error.response?.data.code === "AUTH500-KAKAO_USERINFO_FAILED")
-        addToast("카카오 사용자 정보 조회에 실패했어요", "warning");
-      else if (error.response?.data.code === "AUTH409-EMAIL_RECENTLY_DELETED")
-        addToast("탈퇴한 사용자에요", "warning");
-      else addToast("잠시 후 다시 시도해 주세요", "warning");
-      router.replace("/login");
-    },
-  });
-};
+export const useApiKakaoLogin = () =>
+  useApiSocialLogin<KakaoRequestType, KakaoLoginResponseType>("kakao");

--- a/src/api/fetch/auth/api/useApiSocialLogin.ts
+++ b/src/api/fetch/auth/api/useApiSocialLogin.ts
@@ -1,0 +1,52 @@
+import useAppMutation from "@/api/_base/query/useAppMutation";
+import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
+import { useToast } from "@/context/ToastContext";
+import { useRouter } from "next/navigation";
+import { AUTH_LOGIN_SUCCESS_EVENT } from "@/constants";
+import { AxiosError } from "axios";
+
+type SocialProvider = "kakao" | "apple";
+
+const ERROR_MESSAGES: Record<SocialProvider, Record<string, string>> = {
+  kakao: {
+    "AUTH400-KAKAO_CODE_INVALID": "카카오 인증코드가 유효하지 않거나 이미 사용되었어요",
+    "AUTH500-KAKAO_USERINFO_FAILED": "카카오 사용자 정보 조회에 실패했어요",
+    "AUTH409-EMAIL_RECENTLY_DELETED": "탈퇴한 사용자에요",
+  },
+  apple: {
+    "AUTH400-APPLE_CODE_INVALID": "애플 인증코드가 유효하지 않거나 이미 사용되었어요",
+    "AUTH401-APPLE_ID_TOKEN_INVALID": "애플 인증 정보를 확인할 수 없어요",
+  },
+};
+
+export const useApiSocialLogin = <
+  TRequest extends { code: string; environment: string },
+  TResponse,
+>(
+  provider: SocialProvider
+) => {
+  const router = useRouter();
+
+  const { addToast } = useToast();
+
+  return useAppMutation<TRequest, TResponse, AxiosError<ApiBaseResponseType<null>>>(
+    "auth",
+    `/auth/${provider}`,
+    "post",
+    {
+      onSuccess: () => {
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent(AUTH_LOGIN_SUCCESS_EVENT));
+        }
+      },
+      onError: (error) => {
+        const code = error.response?.data.code;
+        addToast(
+          (code && ERROR_MESSAGES[provider][code]) || "잠시 후 다시 시도해 주세요",
+          "warning"
+        );
+        router.replace("/login");
+      },
+    }
+  );
+};

--- a/src/api/fetch/auth/index.ts
+++ b/src/api/fetch/auth/index.ts
@@ -2,6 +2,7 @@ export * from "./types/ApiFindPwType";
 export * from "./types/CheckCodeResponseType";
 export * from "./types/ApiSingUpType";
 export * from "./types/KakaoLoginResponseType";
+export * from "./types/AppleLoginResponseType";
 
 export { useApiCheckCode } from "./api/useApiCheckCode";
 export { useApiCheckNickname } from "./api/useApiCheckNickname";
@@ -9,6 +10,7 @@ export { useApiFindPw } from "./api/useApiFindPw";
 export { useApiSendEmail } from "./api/useApiSendEmail";
 export { useApiSignUp } from "./api/useApiSignUp";
 export { useApiKakaoLogin } from "./api/useApiKakaoLogin";
+export { useApiAppleLogin } from "./api/useApiAppleLogin";
 export { useApiRefreshToken } from "./api/useApiRefreshToken";
 export { useApiLogout } from "./api/useApiLogout";
 export { useApiEmailLogin } from "./api/useApiEmailLogin";

--- a/src/api/fetch/auth/types/AppleLoginResponseType.ts
+++ b/src/api/fetch/auth/types/AppleLoginResponseType.ts
@@ -1,0 +1,9 @@
+import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
+
+export interface AppleLoginResponseType extends ApiBaseResponseType<AppleLoginType> {}
+
+export interface AppleLoginType {
+  userId: number;
+  isTemporaryPassword: boolean;
+  termsAgreed: boolean;
+}

--- a/src/api/fetch/user/api/usePatchKakaoTerms.ts
+++ b/src/api/fetch/user/api/usePatchKakaoTerms.ts
@@ -2,6 +2,7 @@ import useAppMutation from "@/api/_base/query/useAppMutation";
 import { ApiBaseResponseType } from "@/api/_base/types/ApiBaseResponseType";
 import { useAgreeStore } from "@/store";
 import { useRouter } from "next/navigation";
+import { isValidCallbackUrl } from "@/utils";
 
 export interface KakaoTermType {
   privacyPolicyAgreed?: boolean;
@@ -21,7 +22,9 @@ export const usePatchKakaoTerms = () => {
     {
       onSuccess: () => {
         setAgreed();
-        router.replace("/");
+        const rawCallback = sessionStorage.getItem("callbackUrl");
+        sessionStorage.removeItem("callbackUrl");
+        router.replace(isValidCallbackUrl(rawCallback) ? rawCallback : "/");
       },
     }
   );

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.stories.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import AppleContainer from "./AppleContainer";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/providers/ToastProviders";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const meta: Meta<typeof AppleContainer> = {
+  title: "페이지/애플 로그인 페이지/AppleContainer",
+  component: AppleContainer,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/auth/apple/callback",
+        query: {},
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <div className="w-[390px]">
+            <Story />
+          </div>
+        </ToastProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AppleContainer>;
+
+export const Default: Story = {};

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.test.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AppleContainer from "./AppleContainer";
+
+const mockAppleLoginMutate = jest.fn();
+const mockApplePatchMutate = jest.fn();
+const mockUseApiAppleLogin = jest.fn();
+const mockUsePatchKakaoTerms = jest.fn();
+const mockUseAgreeStore = jest.fn();
+const mockRouterReplace = jest.fn();
+const mockRouterPush = jest.fn();
+const mockUseSearchParams = jest.fn();
+
+jest.mock("@/api/fetch/auth", () => ({
+  useApiAppleLogin: () => mockUseApiAppleLogin(),
+}));
+
+jest.mock("@/api/fetch/user", () => ({
+  usePatchKakaoTerms: () => mockUsePatchKakaoTerms(),
+}));
+
+jest.mock("@/store", () => ({
+  useAgreeStore: () => mockUseAgreeStore(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+jest.mock("../AppleLoading/AppleLoading", () => ({
+  __esModule: true,
+  default: () => <div data-testid="apple-loading">로그인 요청 중...</div>,
+}));
+
+jest.mock("@/components/domain", () => ({
+  TermsAgreement: ({ onComplete, onOpenDetail, isPending }: any) => (
+    <div data-testid="terms-agreement">
+      <button type="button" onClick={onComplete}>
+        약관 완료
+      </button>
+      <button type="button" onClick={() => onOpenDetail("privacyPolicy")}>
+        약관 상세
+      </button>
+      {isPending && <span>처리 중</span>}
+    </div>
+  ),
+  Terms: ({ termName, onAgree }: any) => (
+    <div data-testid="terms">
+      <span data-testid="term-name">{termName}</span>
+      <button type="button" onClick={onAgree}>
+        동의
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/state", () => ({
+  ErrorView: () => <div data-testid="error-view">페이지를 찾을 수 없습니다.</div>,
+}));
+
+const noCodeParams = { get: (key: string) => (key === "code" ? null : null) };
+const withCodeParams = { get: (key: string) => (key === "code" ? "test-auth-code" : null) };
+const withTermNameParams = { get: (key: string) => (key === "termName" ? "privacyPolicy" : null) };
+
+describe("<AppleContainer />", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApiAppleLogin.mockReturnValue({ mutate: mockAppleLoginMutate });
+    mockUsePatchKakaoTerms.mockReturnValue({ mutate: mockApplePatchMutate, isPending: false });
+    mockUseAgreeStore.mockReturnValue({ termsAgreed: false, isLoggedIn: false, login: jest.fn() });
+    mockUseSearchParams.mockReturnValue(noCodeParams);
+  });
+
+  describe("code 파라미터 있음 (Loading step)", () => {
+    beforeEach(() => {
+      mockUseSearchParams.mockReturnValue(withCodeParams);
+    });
+
+    it("AppleLoading이 렌더된다", () => {
+      mockAppleLoginMutate.mockImplementation(() => {});
+      render(<AppleContainer />);
+      expect(screen.getByTestId("apple-loading")).toBeInTheDocument();
+    });
+
+    it("마운트 시 AppleLoginMutate가 code와 함께 호출된다", async () => {
+      mockAppleLoginMutate.mockImplementation(() => {});
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(mockAppleLoginMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ code: "test-auth-code" }),
+          expect.any(Object)
+        );
+      });
+    });
+  });
+
+  describe("onSuccess — termsAgreed=true", () => {
+    beforeEach(() => {
+      mockUseSearchParams.mockReturnValue(withCodeParams);
+      mockAppleLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
+        onSuccess({ result: { termsAgreed: true } });
+      });
+    });
+
+    it("login(true)가 호출된다", async () => {
+      const mockLogin = jest.fn();
+      mockUseAgreeStore.mockReturnValue({
+        termsAgreed: false,
+        isLoggedIn: false,
+        login: mockLogin,
+      });
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it("router.replace('/')가 호출된다", async () => {
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith("/");
+      });
+    });
+  });
+
+  describe("onSuccess — termsAgreed=false", () => {
+    beforeEach(() => {
+      mockUseSearchParams.mockReturnValue(withCodeParams);
+      mockAppleLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
+        onSuccess({ result: { termsAgreed: false } });
+      });
+    });
+
+    it("login(false)가 호출된다", async () => {
+      const mockLogin = jest.fn();
+      mockUseAgreeStore.mockReturnValue({
+        termsAgreed: false,
+        isLoggedIn: false,
+        login: mockLogin,
+      });
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("step이 Term으로 변경되어 TermsAgreement가 렌더된다", async () => {
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(screen.getByTestId("terms-agreement")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("code 없음, isLoggedIn=true, termsAgreed=false (Term step)", () => {
+    it("TermsAgreement가 렌더된다", () => {
+      mockUseAgreeStore.mockReturnValue({ termsAgreed: false, isLoggedIn: true, login: jest.fn() });
+      mockUseSearchParams.mockReturnValue(noCodeParams);
+      render(<AppleContainer />);
+      expect(screen.getByTestId("terms-agreement")).toBeInTheDocument();
+    });
+  });
+
+  describe("termName 파라미터 있음", () => {
+    beforeEach(() => {
+      mockUseSearchParams.mockReturnValue(withTermNameParams);
+    });
+
+    it("Terms가 렌더된다", () => {
+      render(<AppleContainer />);
+      expect(screen.getByTestId("terms")).toBeInTheDocument();
+    });
+
+    it("onAgree 클릭 시 router.push('/auth/apple/callback')이 호출된다", () => {
+      render(<AppleContainer />);
+      fireEvent.click(screen.getByRole("button", { name: "동의" }));
+      expect(mockRouterPush).toHaveBeenCalledWith("/auth/apple/callback");
+    });
+  });
+
+  describe("code 없음, isLoggedIn=false (NoAction step)", () => {
+    it("ErrorView가 렌더된다", () => {
+      mockUseAgreeStore.mockReturnValue({
+        termsAgreed: false,
+        isLoggedIn: false,
+        login: jest.fn(),
+      });
+      mockUseSearchParams.mockReturnValue(noCodeParams);
+      render(<AppleContainer />);
+      expect(screen.getByTestId("error-view")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.test.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.test.tsx
@@ -60,12 +60,19 @@ jest.mock("@/components/state", () => ({
 }));
 
 const noCodeParams = { get: (key: string) => (key === "code" ? null : null) };
-const withCodeParams = { get: (key: string) => (key === "code" ? "test-auth-code" : null) };
+const withCodeParams = {
+  get: (key: string) => {
+    if (key === "code") return "test-auth-code";
+    if (key === "state") return "test-state";
+    return null;
+  },
+};
 const withTermNameParams = { get: (key: string) => (key === "termName" ? "privacyPolicy" : null) };
 
 describe("<AppleContainer />", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
     mockUseApiAppleLogin.mockReturnValue({ mutate: mockAppleLoginMutate });
     mockUsePatchKakaoTerms.mockReturnValue({ mutate: mockApplePatchMutate, isPending: false });
     mockUseAgreeStore.mockReturnValue({ termsAgreed: false, isLoggedIn: false, login: jest.fn() });
@@ -74,6 +81,7 @@ describe("<AppleContainer />", () => {
 
   describe("code 파라미터 있음 (Loading step)", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
     });
 
@@ -97,6 +105,7 @@ describe("<AppleContainer />", () => {
 
   describe("onSuccess — termsAgreed=true", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
       mockAppleLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
         onSuccess({ result: { termsAgreed: true } });
@@ -126,6 +135,7 @@ describe("<AppleContainer />", () => {
 
   describe("onSuccess — termsAgreed=false", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
       mockAppleLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
         onSuccess({ result: { termsAgreed: false } });
@@ -189,6 +199,21 @@ describe("<AppleContainer />", () => {
       mockUseSearchParams.mockReturnValue(noCodeParams);
       render(<AppleContainer />);
       expect(screen.getByTestId("error-view")).toBeInTheDocument();
+    });
+  });
+
+  describe("state 불일치 (CSRF)", () => {
+    beforeEach(() => {
+      sessionStorage.setItem("oauthState", "stored-state");
+      mockUseSearchParams.mockReturnValue(withCodeParams);
+    });
+
+    it("AppleLoginMutate가 호출되지 않고 ErrorView가 렌더된다", async () => {
+      render(<AppleContainer />);
+      await waitFor(() => {
+        expect(screen.getByTestId("error-view")).toBeInTheDocument();
+      });
+      expect(mockAppleLoginMutate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.tsx
@@ -1,0 +1,124 @@
+"use client";
+"use no memo";
+
+import { useApiAppleLogin } from "@/api/fetch/auth";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { Terms, TermsAgreement, ErrorView } from "@/components";
+import { FormProvider, useForm } from "react-hook-form";
+import AppleLoading from "../AppleLoading/AppleLoading";
+import { useAgreeStore } from "@/store";
+import { usePatchKakaoTerms } from "@/api/fetch/user";
+import { isValidCallbackUrl } from "@/utils";
+
+const AppleContainer = () => {
+  const { termsAgreed, isLoggedIn, login } = useAgreeStore();
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const code = searchParams.get("code");
+  const termName = searchParams.get("termName") ?? "";
+
+  const [step, setStep] = useState<"Term" | "Loading" | "NoAction">(() => {
+    if (code) return "Loading";
+    if (isLoggedIn && !termsAgreed) return "Term";
+    return "NoAction";
+  });
+
+  const isRequesting = useRef(false);
+
+  const { mutate: AppleLoginMutate } = useApiAppleLogin();
+  const { mutate: ApplePatchMutate, isPending } = usePatchKakaoTerms();
+
+  const appEnv =
+    process.env.NEXT_PUBLIC_APP_ENV || (process.env.NODE_ENV === "production" ? "prod" : "dev");
+
+  useEffect(() => {
+    if (!code || step === "Term") return;
+    if (isRequesting.current) return;
+
+    isRequesting.current = true;
+    if (code) {
+      AppleLoginMutate(
+        {
+          code: code,
+          environment: appEnv,
+        },
+        {
+          onSuccess: (res) => {
+            const { termsAgreed } = res.result;
+            login(termsAgreed);
+
+            if (termsAgreed) {
+              const rawCallback = sessionStorage.getItem("callbackUrl");
+              sessionStorage.removeItem("callbackUrl");
+              router.replace(isValidCallbackUrl(rawCallback) ? rawCallback : "/");
+            } else {
+              setStep("Term");
+            }
+          },
+        }
+      );
+    }
+
+    if (isLoggedIn && !termsAgreed) {
+      setStep("Term");
+    }
+  }, [code, AppleLoginMutate, router, appEnv, login, step]);
+
+  const methods = useForm();
+  const { setValue } = methods;
+
+  const handleSubmit = () => {
+    const values = methods.getValues();
+    const payload = {
+      privacyPolicyAgreed: values.privacyPolicyAgreed,
+      termsOfServiceAgreed: values.termsOfServiceAgreed,
+      contentPolicyAgreed: values.contentPolicyAgreed,
+      marketingConsent: values.marketingConsent,
+    };
+    ApplePatchMutate(payload);
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        {step === "Term" && !termName && (
+          <TermsAgreement
+            onComplete={handleSubmit}
+            onOpenDetail={(termName) => router.push(`/auth/apple/callback?termName=${termName}`)}
+            isPending={isPending}
+          />
+        )}
+        {termName && (
+          <Terms
+            termName={termName}
+            onAgree={() => {
+              setValue(termName, true, { shouldDirty: true, shouldValidate: true });
+              router.push(`/auth/apple/callback`);
+            }}
+            showButton={true}
+            pageType="SIGN_UP"
+          />
+        )}
+      </form>
+
+      {step === "Loading" && <AppleLoading />}
+      {step === "NoAction" && (
+        <ErrorView
+          iconName="NotFound"
+          code="404"
+          title="페이지를 찾을 수 없습니다."
+          description={
+            <>
+              존재하지 않는 주소를 입력했거나 <br />
+              요청하신 페이지를 사용할 수 없습니다.
+            </>
+          }
+        />
+      )}
+    </FormProvider>
+  );
+};
+
+export default AppleContainer;

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleContainer/AppleContainer.tsx
@@ -9,7 +9,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import AppleLoading from "../AppleLoading/AppleLoading";
 import { useAgreeStore } from "@/store";
 import { usePatchKakaoTerms } from "@/api/fetch/user";
-import { isValidCallbackUrl } from "@/utils";
+import { isValidCallbackUrl, verifyOAuthState } from "@/utils";
 
 const AppleContainer = () => {
   const { termsAgreed, isLoggedIn, login } = useAgreeStore();
@@ -17,6 +17,7 @@ const AppleContainer = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
+  const state = searchParams.get("state");
   const termName = searchParams.get("termName") ?? "";
 
   const [step, setStep] = useState<"Term" | "Loading" | "NoAction">(() => {
@@ -38,6 +39,12 @@ const AppleContainer = () => {
     if (isRequesting.current) return;
 
     isRequesting.current = true;
+
+    if (!verifyOAuthState(state)) {
+      setStep("NoAction");
+      return;
+    }
+
     if (code) {
       AppleLoginMutate(
         {
@@ -64,7 +71,7 @@ const AppleContainer = () => {
     if (isLoggedIn && !termsAgreed) {
       setStep("Term");
     }
-  }, [code, AppleLoginMutate, router, appEnv, login, step]);
+  }, [code, state, AppleLoginMutate, router, appEnv, login, step]);
 
   const methods = useForm();
   const { setValue } = methods;

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.stories.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import AppleLoading from "./AppleLoading";
+
+const meta: Meta<typeof AppleLoading> = {
+  title: "페이지/애플 로그인 페이지/AppleLoading",
+  component: AppleLoading,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[390px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AppleLoading>;
+
+export const Default: Story = {};

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.test.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AppleLoading from "./AppleLoading";
+
+jest.mock("@/components/common", () => ({
+  Icon: ({ name }: any) => <span data-testid={`icon-${name}`} />,
+}));
+
+describe("<AppleLoading />", () => {
+  it("'로그인 요청 중...' 텍스트가 렌더된다", () => {
+    render(<AppleLoading />);
+    expect(screen.getByText("로그인 요청 중...")).toBeInTheDocument();
+  });
+
+  it("Loading 아이콘이 렌더된다", () => {
+    render(<AppleLoading />);
+    expect(screen.getByTestId("icon-Loading")).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/AppleLoading/AppleLoading.tsx
@@ -1,0 +1,14 @@
+import { Icon } from "@/components";
+
+const AppleLoading = () => {
+  return (
+    <div className="flex min-h-screen w-full flex-col-center">
+      <div className="flex flex-col items-center gap-4">
+        <Icon name="Loading" className="animate-spin" size={40} />
+        <p className="text-body1-regular text-gray-700">로그인 요청 중...</p>
+      </div>
+    </div>
+  );
+};
+
+export default AppleLoading;

--- a/src/app/[locale]/(route)/auth/apple/callback/_components/index.ts
+++ b/src/app/[locale]/(route)/auth/apple/callback/_components/index.ts
@@ -1,0 +1,2 @@
+export { default as AppleContainer } from "./AppleContainer/AppleContainer";
+export { default as AppleLoading } from "./AppleLoading/AppleLoading";

--- a/src/app/[locale]/(route)/auth/apple/callback/layout.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+export const metadata: Metadata = {
+  title: "애플 로그인",
+  description: "애플 계정으로 간편하게 로그인하여 분실물을 찾고 습득물을 공유해보세요.",
+  other: { "page-type": "apple-callback" },
+};
+
+const layout = ({ children }: { children: React.ReactNode }) => {
+  return <Suspense fallback="">{children}</Suspense>;
+};
+
+export default layout;

--- a/src/app/[locale]/(route)/auth/apple/callback/page.tsx
+++ b/src/app/[locale]/(route)/auth/apple/callback/page.tsx
@@ -1,0 +1,7 @@
+import { AppleContainer } from "./_components";
+
+const AppleCallbackPage = () => {
+  return <AppleContainer />;
+};
+
+export default AppleCallbackPage;

--- a/src/app/[locale]/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.test.tsx
+++ b/src/app/[locale]/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.test.tsx
@@ -60,12 +60,19 @@ jest.mock("@/components/state", () => ({
 }));
 
 const noCodeParams = { get: (key: string) => (key === "code" ? null : null) };
-const withCodeParams = { get: (key: string) => (key === "code" ? "test-auth-code" : null) };
+const withCodeParams = {
+  get: (key: string) => {
+    if (key === "code") return "test-auth-code";
+    if (key === "state") return "test-state";
+    return null;
+  },
+};
 const withTermNameParams = { get: (key: string) => (key === "termName" ? "privacyPolicy" : null) };
 
 describe("<KakaoContainer />", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
     mockUseApiKakaoLogin.mockReturnValue({ mutate: mockKakaoLoginMutate });
     mockUsePatchKakaoTerms.mockReturnValue({ mutate: mockKakaoPatchMutate, isPending: false });
     mockUseAgreeStore.mockReturnValue({ termsAgreed: false, isLoggedIn: false, login: jest.fn() });
@@ -74,6 +81,7 @@ describe("<KakaoContainer />", () => {
 
   describe("code 파라미터 있음 (Loading step)", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
     });
 
@@ -97,6 +105,7 @@ describe("<KakaoContainer />", () => {
 
   describe("onSuccess — termsAgreed=true", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
       mockKakaoLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
         onSuccess({ result: { termsAgreed: true } });
@@ -126,6 +135,7 @@ describe("<KakaoContainer />", () => {
 
   describe("onSuccess — termsAgreed=false", () => {
     beforeEach(() => {
+      sessionStorage.setItem("oauthState", "test-state");
       mockUseSearchParams.mockReturnValue(withCodeParams);
       mockKakaoLoginMutate.mockImplementation((_payload: any, { onSuccess }: any) => {
         onSuccess({ result: { termsAgreed: false } });
@@ -189,6 +199,21 @@ describe("<KakaoContainer />", () => {
       mockUseSearchParams.mockReturnValue(noCodeParams);
       render(<KakaoContainer />);
       expect(screen.getByTestId("error-view")).toBeInTheDocument();
+    });
+  });
+
+  describe("state 불일치 (CSRF)", () => {
+    beforeEach(() => {
+      sessionStorage.setItem("oauthState", "stored-state");
+      mockUseSearchParams.mockReturnValue(withCodeParams);
+    });
+
+    it("KakaoLoginMutate가 호출되지 않고 ErrorView가 렌더된다", async () => {
+      render(<KakaoContainer />);
+      await waitFor(() => {
+        expect(screen.getByTestId("error-view")).toBeInTheDocument();
+      });
+      expect(mockKakaoLoginMutate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/[locale]/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
+++ b/src/app/[locale]/(route)/auth/kakao/callback/_components/KakaoContainer/KakaoContainer.tsx
@@ -9,7 +9,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import KakaoLoading from "../KakaoLoading/KakaoLoading";
 import { useAgreeStore } from "@/store";
 import { usePatchKakaoTerms } from "@/api/fetch/user";
-import { isValidCallbackUrl } from "@/utils";
+import { isValidCallbackUrl, verifyOAuthState } from "@/utils";
 
 const KakaoContainer = () => {
   const { termsAgreed, isLoggedIn, login } = useAgreeStore();
@@ -17,6 +17,7 @@ const KakaoContainer = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
+  const state = searchParams.get("state");
   const termName = searchParams.get("termName") ?? "";
 
   const [step, setStep] = useState<"Term" | "Loading" | "NoAction">(() => {
@@ -38,6 +39,12 @@ const KakaoContainer = () => {
     if (isRequesting.current) return;
 
     isRequesting.current = true;
+
+    if (!verifyOAuthState(state)) {
+      setStep("NoAction");
+      return;
+    }
+
     if (code) {
       KakaoLoginMutate(
         {
@@ -64,7 +71,7 @@ const KakaoContainer = () => {
     if (isLoggedIn && !termsAgreed) {
       setStep("Term");
     }
-  }, [code, KakaoLoginMutate, router, appEnv, login, step]);
+  }, [code, state, KakaoLoginMutate, router, appEnv, login, step]);
 
   const methods = useForm();
   const { setValue } = methods;

--- a/src/app/[locale]/(route)/login/page.tsx
+++ b/src/app/[locale]/(route)/login/page.tsx
@@ -7,6 +7,7 @@ import { Button, Icon } from "@/components";
 import useSessionNotification from "./_hooks/useSessionNotification";
 import { LogoLink } from "./_components";
 import { useSearchParams } from "next/navigation";
+import { createOAuthState } from "@/utils";
 import {
   trackClickAppleLogin,
   trackClickSignupStart,
@@ -18,11 +19,11 @@ const ButtonStyle = "w-full h-11 flex-center gap-1 rounded-[10px] text-body1-sem
 
 const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
 const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
-const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+const kakaoBaseUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
 const APPLE_CLIENT_ID = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID;
 const APPLE_REDIRECT_URI = process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI;
-const appleURL = `https://appleid.apple.com/auth/authorize?client_id=${APPLE_CLIENT_ID}&redirect_uri=${APPLE_REDIRECT_URI}&response_type=code`;
+const appleBaseUrl = `https://appleid.apple.com/auth/authorize?client_id=${APPLE_CLIENT_ID}&redirect_uri=${APPLE_REDIRECT_URI}&response_type=code`;
 
 const page = () => {
   const t = useTranslations("Login");
@@ -45,7 +46,9 @@ const page = () => {
     if (callbackUrl) sessionStorage.setItem("callbackUrl", callbackUrl);
     else sessionStorage.removeItem("callbackUrl");
 
-    window.location.replace(provider === "kakao" ? kakaoURL : appleURL);
+    const state = createOAuthState();
+    const baseUrl = provider === "kakao" ? kakaoBaseUrl : appleBaseUrl;
+    window.location.replace(`${baseUrl}&state=${state}`);
   };
 
   return (

--- a/src/app/[locale]/(route)/login/page.tsx
+++ b/src/app/[locale]/(route)/login/page.tsx
@@ -20,6 +20,10 @@ const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
 const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
 const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
+const APPLE_CLIENT_ID = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID;
+const APPLE_REDIRECT_URI = process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI;
+const appleURL = `https://appleid.apple.com/auth/authorize?client_id=${APPLE_CLIENT_ID}&redirect_uri=${APPLE_REDIRECT_URI}&response_type=code`;
+
 const page = () => {
   const t = useTranslations("Login");
   const { reason } = useSessionNotification();
@@ -34,18 +38,14 @@ const page = () => {
     return query ? `/login/email?${query}` : "/login/email";
   })();
 
-  const handleKakaoLogin = () => {
-    trackClickKakaoLogin();
+  const handleSocialLogin = (provider: "kakao" | "apple") => {
+    if (provider === "kakao") trackClickKakaoLogin();
+    else trackClickAppleLogin();
 
     if (callbackUrl) sessionStorage.setItem("callbackUrl", callbackUrl);
     else sessionStorage.removeItem("callbackUrl");
 
-    window.location.replace(kakaoURL);
-  };
-
-  const handleAppleLogin = () => {
-    trackClickAppleLogin();
-    alert("애플 로그인은 현재 지원하지 않습니다.");
+    window.location.replace(provider === "kakao" ? kakaoURL : appleURL);
   };
 
   return (
@@ -58,7 +58,7 @@ const page = () => {
           type="submit"
           ignoreBase
           ariaLabel={t("kakaoAriaLabel")}
-          onClick={handleKakaoLogin}
+          onClick={() => handleSocialLogin("kakao")}
           className={cn(
             ButtonStyle,
             "gap-1 text-flatGray-900 bg-fill-accent-kakao hover:bg-fill-accent-kakao"
@@ -71,7 +71,7 @@ const page = () => {
           type="submit"
           ignoreBase
           ariaLabel={t("appleAriaLabel")}
-          onClick={handleAppleLogin}
+          onClick={() => handleSocialLogin("apple")}
           className={cn(
             ButtonStyle,
             "gap-1 bg-labelsVibrant-primary text-white hover:bg-labelsVibrant-primary"

--- a/src/providers/TermsProvider.tsx
+++ b/src/providers/TermsProvider.tsx
@@ -14,7 +14,7 @@ export const TermsProvider = ({ children }: { children: ReactNode }) => {
     if (!isAuthInitialized) return;
 
     if (isLoggedIn && !termsAgreed) {
-      if (!pathname.startsWith("/auth/kakao")) {
+      if (!pathname.startsWith("/auth/kakao") && !pathname.startsWith("/auth/apple")) {
         router.replace("/auth/kakao/callback");
       }
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,6 +29,7 @@ export { formatMetadataKeyword } from "./formatMetadataKeyword/formatMetadataKey
 export { formatMetadataAddress } from "./formatMetadataAddress/formatMetadataAddress";
 export { extractDongAddress } from "./extractDongAddress/extractDongAddress";
 export { isValidCallbackUrl } from "./isValidCallbackUrl/isValidCallbackUrl";
+export { createOAuthState, verifyOAuthState } from "./oauthState/oauthState";
 export { isWebPushSupported } from "./webPush/isWebPushSupported/isWebPushSupported";
 export { registerWebPushServiceWorker } from "./webPush/registerWebPushServiceWorker/registerWebPushServiceWorker";
 export { syncWebPushSubscription } from "./webPush/syncWebPushSubscription/syncWebPushSubscription";

--- a/src/utils/oauthState/oauthState.ts
+++ b/src/utils/oauthState/oauthState.ts
@@ -1,0 +1,13 @@
+const OAUTH_STATE_KEY = "oauthState";
+
+export const createOAuthState = () => {
+  const state = crypto.randomUUID();
+  sessionStorage.setItem(OAUTH_STATE_KEY, state);
+  return state;
+};
+
+export const verifyOAuthState = (receivedState: string | null) => {
+  const storedState = sessionStorage.getItem(OAUTH_STATE_KEY);
+  sessionStorage.removeItem(OAUTH_STATE_KEY);
+  return !!receivedState && !!storedState && receivedState === storedState;
+};

--- a/tests/e2e/notice.spec.ts
+++ b/tests/e2e/notice.spec.ts
@@ -82,7 +82,6 @@ test.describe("공지사항 목록", () => {
       test.setTimeout(90_000);
       const noticeLink = page.locator('a[href="/notice/1"]');
       await expect(noticeLink).toBeVisible({ timeout: 30_000 });
-      await noticeLink.scrollIntoViewIfNeeded();
       await noticeLink.click();
 
       await expect(page).toHaveURL(/\/notice\/1\/?$/, { timeout: 35_000 });


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 애플 로그인 관련 API 및 훅 추가, 수정 진행

## 참고 사항

- env 파일은 컨플루언스에 빠른 시일내에 업데이트를 할 예정이고 확인 부탁드립니다.

- 애플 로그인은 `https://...` 환경에서 가능함으로 ngrok을 사용하여 테스트를 진행하였고, 성공적이였습니다.  

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
