### PR TITLE
fix: /terms/[termName] 메타데이터 및 컨텐츠 높이 오류 수정

### DIFF
--- a/src/app/[locale]/(route)/terms/[termName]/layout.tsx
+++ b/src/app/[locale]/(route)/terms/[termName]/layout.tsx
@@ -1,12 +1,34 @@
 import type { Metadata } from "next";
 import { ReactNode } from "react";
+import { TERM_CONTENTS } from "@/components/domain/Terms/_constants/TERM_CONTENTS";
 
-export const metadata: Metadata = {
-  title: "이용 약관",
-  description: "찾아줘 서비스에 액세스하거나 서비스를 이용할 때 적용되는 약관을 확인해 보세요.",
-  other: { "page-type": "terms" },
+interface LayoutProps {
+  children: ReactNode;
+  params: Promise<{ termName: string }>;
+}
+
+const TERM_HEADER_BY_ROUTE_PARAM: Record<string, string> = {
+  privacy: TERM_CONTENTS.privacyPolicyAgreed.termHeader,
+  service: TERM_CONTENTS.termsOfServiceAgreed.termHeader,
+  marketing: TERM_CONTENTS.marketingConsent.termHeader,
+  contentPolicy: TERM_CONTENTS.contentPolicyAgreed.termHeader,
 };
 
-export default function Layout({ children }: { children: ReactNode }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: LayoutProps["params"];
+}): Promise<Metadata> {
+  const { termName } = await params;
+  const termHeader = TERM_HEADER_BY_ROUTE_PARAM[termName] ?? "이용 약관";
+
+  return {
+    title: termHeader,
+    description: `찾아줘 서비스의 ${termHeader} 내용을 확인해 보세요.`,
+    other: { "page-type": "terms" },
+  };
+}
+
+export default function Layout({ children }: LayoutProps) {
   return <>{children}</>;
 }

--- a/src/components/domain/Terms/Terms.tsx
+++ b/src/components/domain/Terms/Terms.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { DetailHeader } from "@/components/layout";
 import { FooterButton } from "@/components/domain";
 import { CheckBox } from "@/components/common";
+import { cn } from "@/utils";
 import { TERM_CONTENTS } from "./_constants/TERM_CONTENTS";
 import { useGetNotificationSetting, usePutNotificationSetting } from "@/api/fetch/notification";
 import { DEFAULT_NOTIFICATION_SETTING } from "@/app/[locale]/(route)/mypage/notifications/_constants/DEFAULT_NOTIFICATION_SETTING";
@@ -51,7 +52,12 @@ const Terms = ({ termName, onAgree, showButton = false, pageType = "TERM" }: Ter
   return (
     <>
       <DetailHeader title={pageType === "TERM" ? termHeader : title} />
-      <div className="whitespace-pre-wrap px-4 pb-[calc(88px+24px)] pt-6 text-body2-regular text-layout-body-default h-hfb-base">
+      <div
+        className={cn(
+          "whitespace-pre-wrap px-4 pt-6 text-body2-regular text-layout-body-default",
+          showButton ? "pb-[calc(88px+24px)] h-hfb-base" : "pb-6 h-base"
+        )}
+      >
         {pageType === "TERM" && isOptionalTerm && (
           <>
             <div className="flex h-11 w-full items-center">


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `/terms/[termName]` 라우트가 termName과 무관하게 항상 동일한 정적 메타데이터를 내보내던 문제를 수정했습니다. `layout.tsx`의 `metadata` export를 `generateMetadata`로 바꿔 termName(`privacy`/`service`/`marketing`/`contentPolicy`)별로 올바른 제목과 설명을 반환하도록 했습니다. 예를 들어 `/terms/marketing`은 "이용 약관" 대신 "마케팅 수신 약관"으로 표시됩니다.
- `Terms` 컴포넌트가 `showButton`이 `false`(FooterButton이 렌더되지 않는 `/terms/[termName]` 단독 열람 경로)일 때도 FooterButton 공간을 반영한 `h-hfb-base`/`pb-[calc(88px+24px)]`를 그대로 사용해 컨텐츠 컨테이너의 최소 높이가 뷰포트보다 88px 작게 계산되던 문제를 수정했습니다. `showButton` 값에 따라 `h-base`(버튼 없음)/`h-hfb-base`(버튼 있음)를 분기해 좌우 테두리가 화면 하단까지 끊김 없이 이어지도록 했습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거