### PR TITLE
refactor : 소셜 로그인 오류 분기처리에 대한 수정

### DIFF
--- a/src/api/_base/axios/authApi.ts
+++ b/src/api/_base/axios/authApi.ts
@@ -22,7 +22,12 @@ authApi.interceptors.response.use(
     const isAlreadyRetried = originalRequest._retry;
     const isRefreshRequest = originalRequest.url?.includes("auth/refresh");
 
-    if (isRefreshRequest || originalRequest.url?.includes("auth/login")) {
+    const isLoginAttempt =
+      originalRequest.url?.includes("auth/login") ||
+      originalRequest.url?.includes("auth/apple") ||
+      originalRequest.url?.includes("auth/kakao");
+
+    if (isRefreshRequest || isLoginAttempt) {
       return Promise.reject(error);
     }
 


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 401 응답 처리에 대한 소셜 로그인 추가


## 참고 사항

- qa 채널에 언급된 문제이며 아래 내용이 문제 원인입니다!

1. 401 오류에 대한 처리 방식이 잘못되어 있었다 — "로그인 시도 실패"와 "로그인된 사용자의 토큰 만료"를 구분 안 하고 같은 방식으로 처리 ( 이메일 로그인같은 경우는 구분이 되어있어서 문제가 없습니다 )

2. 이전에 로그인했던 유저의 리프레시 토큰이 남아있을 경우, 애플 로그인이 실패해도 그 실패를 그대로 처리하지 않고 무작정 유효한 리프레시 토큰으로 액세스 토큰을 정상 발급해버렸다

3. 그래서 실제로는 로그인(애플)을 실패했지만, 토큰/세션 관점에서는 성공한 것처럼 남아버린다

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거
