### PR TITLE
feat: 로그인 페이지 언어 선택 드롭다운 추가

### DIFF
--- a/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.stories.tsx
+++ b/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from "@storybook/nextjs";
+import LanguageDropdown from "./LanguageDropdown";
+
+const meta: Meta<typeof LanguageDropdown> = {
+  title: "페이지/로그인 페이지/LanguageDropdown",
+  component: LanguageDropdown,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "로그인 페이지에서 언어를 선택할 수 있는 드롭다운 컴포넌트입니다. 선택 시 해당 로케일로 라우팅됩니다.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[116px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LanguageDropdown>;
+
+export const Default: Story = {};

--- a/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.test.tsx
+++ b/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { useLocale } from "next-intl";
+import { useSearchParams } from "next/navigation";
+import LanguageDropdown from "./LanguageDropdown";
+import { usePathname, useRouter } from "@/i18n/navigation";
+
+const mockReplace = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock("@/i18n/navigation", () => ({
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("@/components", () => ({
+  Icon: () => <span />,
+}));
+
+jest.mock("next-intl", () => {
+  const actual = jest.requireActual("next-intl");
+
+  return {
+    ...actual,
+    useTranslations: (namespace?: string) =>
+      actual.createTranslator({
+        locale: "ko",
+        messages: jest.requireActual("@/messages/ko.json"),
+        namespace,
+      }),
+    useLocale: jest.fn(() => "ko"),
+  };
+});
+
+describe("LanguageDropdown", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (usePathname as jest.Mock).mockReturnValue("/login");
+    (useRouter as jest.Mock).mockReturnValue({ replace: mockReplace, refresh: mockRefresh });
+    (useLocale as jest.Mock).mockReturnValue("ko");
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams());
+  });
+
+  it("기본 로케일(한국어)일 때 트리거 버튼에 Language가 표시됩니다", () => {
+    render(<LanguageDropdown />);
+
+    expect(screen.getByRole("button", { name: "언어 선택" })).toHaveTextContent("Language");
+  });
+
+  it("영어 로케일일 때 트리거 버튼에 English가 표시됩니다", () => {
+    (useLocale as jest.Mock).mockReturnValue("en");
+
+    render(<LanguageDropdown />);
+
+    expect(screen.getByRole("button", { name: "언어 선택" })).toHaveTextContent("English");
+  });
+
+  it("트리거 클릭 시 옵션 리스트가 표시됩니다", async () => {
+    const user = userEvent.setup();
+    render(<LanguageDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+
+    expect(screen.getByText("한국어")).toBeInTheDocument();
+    expect(screen.getByText("English")).toBeInTheDocument();
+  });
+
+  it("현재 로케일(한국어) 옵션을 클릭하면 라우팅하지 않고 닫힙니다", async () => {
+    const user = userEvent.setup();
+    render(<LanguageDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByText("한국어"));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(screen.queryByText("English")).not.toBeInTheDocument();
+  });
+
+  it("다른 로케일(English) 옵션을 클릭하면 해당 로케일로 라우팅하고 닫힙니다", async () => {
+    const user = userEvent.setup();
+    render(<LanguageDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByText("English"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/login", { locale: "en" });
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(screen.queryByText("English")).not.toBeInTheDocument();
+  });
+
+  it("쿼리 파라미터(callbackUrl, reason)가 있을 때 로케일 전환 시에도 유지됩니다", async () => {
+    const user = userEvent.setup();
+    (useSearchParams as jest.Mock).mockReturnValue(
+      new URLSearchParams({ callbackUrl: "/mypage", reason: "session-expired" })
+    );
+    render(<LanguageDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByText("English"));
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/login?callbackUrl=%2Fmypage&reason=session-expired",
+      {
+        locale: "en",
+      }
+    );
+  });
+
+  it("외부 클릭 시 드롭다운이 닫힙니다", async () => {
+    const user = userEvent.setup();
+    render(<LanguageDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    expect(screen.getByText("English")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByText("English")).not.toBeInTheDocument();
+  });
+
+  it("트리거를 다시 클릭하면 드롭다운이 닫힙니다", async () => {
+    const user = userEvent.setup();
+    render(<LanguageDropdown />);
+
+    const trigger = screen.getByRole("button", { name: "언어 선택" });
+    await user.click(trigger);
+    expect(screen.getByText("English")).toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(screen.queryByText("English")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.test.tsx
+++ b/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.test.tsx
@@ -49,7 +49,7 @@ describe("LanguageDropdown", () => {
   it("기본 로케일(한국어)일 때 트리거 버튼에 Language가 표시됩니다", () => {
     render(<LanguageDropdown />);
 
-    expect(screen.getByRole("button", { name: "언어 선택" })).toHaveTextContent("Language");
+    expect(screen.getByRole("button", { name: /^언어 선택/ })).toHaveTextContent("Language");
   });
 
   it("영어 로케일일 때 트리거 버튼에 English가 표시됩니다", () => {
@@ -57,14 +57,14 @@ describe("LanguageDropdown", () => {
 
     render(<LanguageDropdown />);
 
-    expect(screen.getByRole("button", { name: "언어 선택" })).toHaveTextContent("English");
+    expect(screen.getByRole("button", { name: /^언어 선택/ })).toHaveTextContent("English");
   });
 
   it("트리거 클릭 시 옵션 리스트가 표시됩니다", async () => {
     const user = userEvent.setup();
     render(<LanguageDropdown />);
 
-    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByRole("button", { name: /^언어 선택/ }));
 
     expect(screen.getByText("한국어")).toBeInTheDocument();
     expect(screen.getByText("English")).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe("LanguageDropdown", () => {
     const user = userEvent.setup();
     render(<LanguageDropdown />);
 
-    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByRole("button", { name: /^언어 선택/ }));
     await user.click(screen.getByText("한국어"));
 
     expect(mockReplace).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe("LanguageDropdown", () => {
     const user = userEvent.setup();
     render(<LanguageDropdown />);
 
-    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByRole("button", { name: /^언어 선택/ }));
     await user.click(screen.getByText("English"));
 
     expect(mockReplace).toHaveBeenCalledWith("/login", { locale: "en" });
@@ -100,7 +100,7 @@ describe("LanguageDropdown", () => {
     );
     render(<LanguageDropdown />);
 
-    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByRole("button", { name: /^언어 선택/ }));
     await user.click(screen.getByText("English"));
 
     expect(mockReplace).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe("LanguageDropdown", () => {
     const user = userEvent.setup();
     render(<LanguageDropdown />);
 
-    await user.click(screen.getByRole("button", { name: "언어 선택" }));
+    await user.click(screen.getByRole("button", { name: /^언어 선택/ }));
     expect(screen.getByText("English")).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);
@@ -127,7 +127,7 @@ describe("LanguageDropdown", () => {
     const user = userEvent.setup();
     render(<LanguageDropdown />);
 
-    const trigger = screen.getByRole("button", { name: "언어 선택" });
+    const trigger = screen.getByRole("button", { name: /^언어 선택/ });
     await user.click(trigger);
     expect(screen.getByText("English")).toBeInTheDocument();
 

--- a/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.tsx
+++ b/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLocale, useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+import { usePopoverOutsideClose, usePopoverPosition } from "@/hooks";
+import { Icon } from "@/components";
+import { cn } from "@/utils";
+
+const LanguageDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const locale = useLocale();
+  const t = useTranslations("Login");
+  const tLanguage = useTranslations("LanguageSwitcher");
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  usePopoverOutsideClose(isOpen, anchorRef, dropdownRef, () => setIsOpen(false));
+  usePopoverPosition(isOpen, anchorRef, dropdownRef);
+
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
+  const handleSelect = (nextLocale: (typeof routing.locales)[number]) => {
+    setIsOpen(false);
+    if (nextLocale === locale) return;
+    const query = searchParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { locale: nextLocale });
+    router.refresh();
+  };
+
+  return (
+    <>
+      <div ref={anchorRef}>
+        <button
+          type="button"
+          aria-label={t("languageAriaLabel")}
+          onClick={toggleDropdown}
+          className="h-10 w-full gap-1.5 rounded-[10px] border border-neutral-normal-default bg-white px-3.5 text-body2-semibold text-neutral-normal-default flex-center"
+        >
+          {locale === routing.defaultLocale ? t("languageLabel") : tLanguage(locale)}
+          <Icon name={isOpen ? "ArrowUp" : "ArrowDown"} size={18} />
+        </button>
+      </div>
+      {isOpen &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            className="glass-card fixed z-50 flex flex-col overflow-hidden rounded-[20px] border border-white bg-flatGray-25/70"
+          >
+            {routing.locales.map((option) => (
+              <button
+                key={option}
+                onClick={() => handleSelect(option)}
+                className={cn(
+                  "h-10 w-full px-7 py-4 text-body2-semibold flex-center",
+                  option === locale
+                    ? "text-brand-strongUseThis-default bg-fill-brand-subtle-default_2"
+                    : "text-neutral-normal-default"
+                )}
+              >
+                {tLanguage(option)}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};
+
+export default LanguageDropdown;

--- a/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.tsx
+++ b/src/app/[locale]/(route)/login/_components/LanguageDropdown/LanguageDropdown.tsx
@@ -39,7 +39,9 @@ const LanguageDropdown = () => {
       <div ref={anchorRef}>
         <button
           type="button"
-          aria-label={t("languageAriaLabel")}
+          aria-label={`${t("languageAriaLabel")}: ${locale === routing.defaultLocale ? t("languageLabel") : tLanguage(locale)}`}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
           onClick={toggleDropdown}
           className="h-10 w-full gap-1.5 rounded-[10px] border border-neutral-normal-default bg-white px-3.5 text-body2-semibold text-neutral-normal-default flex-center"
         >
@@ -51,11 +53,15 @@ const LanguageDropdown = () => {
         createPortal(
           <div
             ref={dropdownRef}
+            role="listbox"
+            aria-label={t("languageAriaLabel")}
             className="glass-card fixed z-50 flex flex-col overflow-hidden rounded-[20px] border border-white bg-flatGray-25/70"
           >
             {routing.locales.map((option) => (
               <button
                 key={option}
+                role="option"
+                aria-selected={option === locale}
                 onClick={() => handleSelect(option)}
                 className={cn(
                   "h-10 w-full px-7 py-4 text-body2-semibold flex-center",

--- a/src/app/[locale]/(route)/login/_components/index.ts
+++ b/src/app/[locale]/(route)/login/_components/index.ts
@@ -1,1 +1,2 @@
 export { default as LogoLink } from "./LogoLink/LogoLink";
+export { default as LanguageDropdown } from "./LanguageDropdown/LanguageDropdown";

--- a/src/app/[locale]/(route)/login/_docs/plan.md
+++ b/src/app/[locale]/(route)/login/_docs/plan.md
@@ -1,0 +1,21 @@
+# login 작업 계획
+
+## 언어 선택 드롭다운 추가
+
+Figma: https://www.figma.com/design/BnMhrCOz7goLFef2jr8Zpf/찾아줘--v2.0?node-id=13614-132558
+
+- [x] `_components/LanguageDropdown/LanguageDropdown.tsx` 작성 (트리거 버튼 아래로 펼쳐지는 옵션 리스트, 선택된 옵션은 브랜드 색상 강조)
+  - `usePopoverOutsideClose`, `usePopoverPosition`(`@/hooks`)로 팝오버 동작 재사용 (FilterDropdown 패턴 참고)
+  - 옵션 목록은 `routing.locales`(`@/i18n/routing`) 기반, 하드코딩 금지
+  - 선택 시 `useRouter`/`usePathname`(`@/i18n/navigation`)으로 locale 전환 (`LanguageSwitcher` 패턴 참고)
+- [x] `login/page.tsx`에 `LanguageDropdown` 배치 (이메일 로그인/회원가입 영역 하단, 가운데 정렬)
+- [x] 선택한 언어가 로그인 이후 라우팅 전반에 유지되는지 확인 — `middleware.ts`의 `createIntlMiddleware(routing)`가 로케일 전환 시 `NEXT_LOCALE` 쿠키를 자동 관리하므로 `router.replace(pathname, { locale })`만으로 충분, 별도 쿠키 처리 불필요
+- [x] 전역 `LanguageSwitcher` 렌더링 제거 — `[locale]/layout.tsx`에서 `<LanguageSwitcher />` 호출부만 제거 (컴포넌트 파일 자체는 보류, 삭제 여부 추후 결정)
+- [x] 번역 키 추가 (`src/messages/ko.json`, `src/messages/en.json`) — `Login.languageLabel`, `Login.languageAriaLabel` 추가, 옵션 라벨은 기존 `LanguageSwitcher.ko`/`LanguageSwitcher.en` 재사용
+- [x] Storybook 스토리 작성 (`LanguageDropdown.stories.tsx`)
+- [x] Jest 테스트 작성 (`LanguageDropdown.test.tsx` — 옵션 렌더링, 선택 시 locale 전환 호출, 외부 클릭 시 닫힘 등, `FilterDropdown.test.tsx` 패턴 참고)
+- [x] 코드 리뷰에서 확인된 버그 수정: `router.replace(pathname, { locale })`의 `pathname`(`@/i18n/navigation`의 `usePathname`)이 쿼리스트링을 포함하지 않아, 언어 전환 시 `callbackUrl`/`reason=session-expired` 등 기존 쿼리 파라미터가 소실됨. `useSearchParams`(`next/navigation`)로 현재 쿼리스트링을 읽어 `pathname`에 이어붙이도록 수정, 회귀 테스트 추가
+
+## 후속 작업 (별도 진행, 별도 plan.md)
+
+- [ ] 마이페이지에 언어 변경 옵션 추가 — 디자인이 달라 `LanguageDropdown`을 공통화하지 않고 마이페이지 라우트 전용으로 새로 작성 (로케일 전환 로직만 `LanguageDropdown` 구현 참고)

--- a/src/app/[locale]/(route)/login/page.tsx
+++ b/src/app/[locale]/(route)/login/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { cn } from "@/utils";
 import { Button, Icon } from "@/components";
 import useSessionNotification from "./_hooks/useSessionNotification";
-import { LogoLink } from "./_components";
+import { LogoLink, LanguageDropdown } from "./_components";
 import { useSearchParams } from "next/navigation";
 import { createOAuthState } from "@/utils";
 import {
@@ -113,6 +113,10 @@ const page = () => {
         >
           {t("createAccount")}
         </Link>
+      </div>
+
+      <div className="w-[116px]">
+        <LanguageDropdown />
       </div>
     </div>
   );

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from "react-dom";
-import { Footer, LanguageSwitcher } from "@/components";
+import { Footer } from "@/components";
 import "../globals.css";
 import AppProviders from "@/providers/AppProviders";
 import { cookies } from "next/headers";
@@ -145,7 +145,6 @@ export default async function RootLayout({
             <MSWProvider />
             <AuthBootstrap />
             <main className="w-full flex-1">{children}</main>
-            <LanguageSwitcher />
             <Footer hasToken={hasToken} />
             <Script
               src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.7/kakao.min.js"

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -427,7 +427,9 @@
     "emailButton": "Log in with email",
     "divider": "Or",
     "notMemberYet": "Don't have an account?",
-    "createAccount": "Create account"
+    "createAccount": "Create account",
+    "languageLabel": "Language",
+    "languageAriaLabel": "Select language"
   },
   "LoginLayout": {
     "title": "Log In",
@@ -1872,15 +1874,7 @@
     "goToAlertPage": "Go to notifications"
   },
   "useFormatKoreanDate": {
-    "weekdays": [
-      "Sunday",
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday"
-    ]
+    "weekdays": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
   },
   "PublicDataCodes": {
     "category": {

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -427,7 +427,9 @@
     "emailButton": "이메일 로그인",
     "divider": "또는",
     "notMemberYet": "아직 회원이 아니신가요?",
-    "createAccount": "회원가입"
+    "createAccount": "회원가입",
+    "languageLabel": "Language",
+    "languageAriaLabel": "언어 선택"
   },
   "LoginLayout": {
     "title": "로그인",
@@ -1872,15 +1874,7 @@
     "goToAlertPage": "알림 페이지로 이동"
   },
   "useFormatKoreanDate": {
-    "weekdays": [
-      "일요일",
-      "월요일",
-      "화요일",
-      "수요일",
-      "목요일",
-      "금요일",
-      "토요일"
-    ]
+    "weekdays": ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
   },
   "PublicDataCodes": {
     "category": {


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호

## 작업 내용

- 로그인 페이지에서 한국어/영어를 선택하면 해당 로케일로 즉시 라우팅되는 LanguageDropdown 컴포넌트를 추가했습니다.
- 언어 목록이 늘어날 예정이라 하드코딩 대신 routing.locales 기반으로 옵션을 구성했습니다.
- 전역으로 떠 있던 LanguageSwitcher 토글 버튼은 로그인 페이지 드롭다운과 진입점이 중복되므로 레이아웃 렌더링을 제거했습니다 (컴포넌트 파일 자체는 마이페이지 대체 UI 작업 전까지 보류했습니다).
- 로케일 전환 시 usePathname이 쿼리스트링을 포함하지 않아 callbackUrl, reason 등의 파라미터가 소실되는 문제를 발견해 useSearchParams로 쿼리를 유지하도록 수정했습니다.
- Storybook 스토리와 Jest 테스트를 추가했습니다.
- login 라우트의 _docs/plan.md에 작업 계획과 진행 상태를 기록했습니다.

## 참고 사항

- 전역 언어 전환 기능이 로그인 페이지 전용으로 좁혀지면서, 로그인 이후 페이지(마이페이지 등)에서 언어를 바꿀 수단이 현재 없습니다. 마이페이지 전용 언어 변경 UI는 디자인이 달라 별도 후속 작업으로 예정되어 있습니다 (plan.md에 기록).
- LanguageSwitcher 컴포넌트 파일은 삭제하지 않고 남겨두었습니다. 삭제 여부는 마이페이지 작업 이후 결정할 예정입니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거