### PR TITLE
chore: i18n 키/리터럴 검증 스크립트를 CI에 연결

### DIFF
--- a/.claude/skills/plan-route/SKILL.md
+++ b/.claude/skills/plan-route/SKILL.md
@@ -33,7 +33,7 @@ description: src/app 하위 특정 라우트(page.tsx가 있는 디렉토리) �
 
 ## 번역(i18n) 체크리스트
 
-새 페이지에 정적 텍스트가 들어가면, 절차 1번에서 plan.md 체크리스트를 작성할 때 아래 항목도 함께 넣는다. `(admin)` 라우트 그룹처럼 i18n 대상에서 제외된 라우트(`eslint.config.mjs`의 ignore 목록 참고)는 생략한다.
+이 라우트에 새로운 정적 텍스트가 추가되면(신규 페이지 생성이든 기존 페이지 수정 중 텍스트 추가든 동일하게), 절차 1번에서 plan.md 체크리스트를 작성할 때 아래 항목도 함께 넣는다. `(admin)` 라우트 그룹처럼 i18n 대상에서 제외된 라우트(`eslint.config.mjs`의 ignore 목록 참고)는 생략한다.
 
 - [ ] 네임스페이스 이름 정하기 (컴포넌트/페이지명 PascalCase, `src/messages/ko.json` 기준 — 구현 전에 먼저 정해서 하드코딩 없이 바로 `t()`로 작성)
 - [ ] 하드코딩 대신 `t()`/`useTranslations`(클라이언트), `getTranslations`(서버)로 구현

--- a/.claude/skills/plan-route/SKILL.md
+++ b/.claude/skills/plan-route/SKILL.md
@@ -31,6 +31,19 @@ description: src/app 하위 특정 라우트(page.tsx가 있는 디렉토리) �
 
 3. **응답을 마치기 전**: plan.md의 상태가 실제 완료 여부와 일치하는지 다시 확인하고 저장한다. 이번 요청 범위에서 착수하지 못한 항목은 `- [ ]`로 남겨 다음 세션이 이어갈 수 있게 한다.
 
+## 번역(i18n) 체크리스트
+
+새 페이지에 정적 텍스트가 들어가면, 절차 1번에서 plan.md 체크리스트를 작성할 때 아래 항목도 함께 넣는다. `(admin)` 라우트 그룹처럼 i18n 대상에서 제외된 라우트(`eslint.config.mjs`의 ignore 목록 참고)는 생략한다.
+
+- [ ] 네임스페이스 이름 정하기 (컴포넌트/페이지명 PascalCase, `src/messages/ko.json` 기준 — 구현 전에 먼저 정해서 하드코딩 없이 바로 `t()`로 작성)
+- [ ] 하드코딩 대신 `t()`/`useTranslations`(클라이언트), `getTranslations`(서버)로 구현
+- [ ] `src/messages/ko.json`, `en.json`에 키를 동시에 추가 (한쪽만 채우고 나중으로 미루지 않기)
+- [ ] `npm run lint:i18n-literal`, `npm run check:i18n-keys` 로컬 실행해 통과 확인
+
+`check:i18n-keys`는 CI(`jest.yml`)에서도 자동으로 실행되어 ko/en 키 불일치 시 PR을 막지만(차단형), `lint:i18n-literal`은 기존 하드코딩 잔여분 때문에 CI에서는 참고용(비차단)으로만 연결되어 있다. 새로 작성한 코드에 하드코딩이 남아 있는지는 로컬에서 직접 확인해야 한다.
+
+로케일마다 표현 방식이 달라 ko/en 키가 의도적으로 비대칭인 경우(예: 복수형 처리 차이)는 `scripts/check-i18n-keys.js`의 `ALLOWED_MISMATCHES` 목록에 추가하면 된다.
+
 ## 주의
 
 - plan.md는 문서일 뿐이다. 코드 변경 없이 plan.md만 갱신하고 끝내지 않는다.

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check i18n key parity (ko/en)
+        run: npm run check:i18n-keys
+
+      - name: Check i18n hardcoded literals (report only)
+        continue-on-error: true
+        run: npm run lint:i18n-literal
+
       - name: Run tests
         run: npm test -- --reporters=jest-junit
 

--- a/scripts/check-i18n-keys.js
+++ b/scripts/check-i18n-keys.js
@@ -5,6 +5,14 @@ const ROOT = path.join(__dirname, "..");
 const MESSAGES_DIR = path.join(ROOT, "src/messages");
 const LOCALES = ["ko", "en"];
 
+// 로케일마다 표현 방식이 달라 의도적으로 키가 대칭이지 않은 항목.
+// key: "네임스페이스.키", value: 해당 키가 없어도 되는 로케일 목록.
+const ALLOWED_MISMATCHES = {
+  // 한국어는 고정 라벨 + 별도 카운트 포맷, 영어는 ICU plural로 처리 (PostDetailBody.tsx의 isKo 분기 참고)
+  "PostDetailBody.favoriteLabel": ["en"],
+  "PostDetailBody.favoriteCountLabel": ["ko"],
+};
+
 function flattenKeys(obj, prefix = "") {
   return Object.entries(obj).reduce((keys, [key, value]) => {
     const fullKey = prefix ? `${prefix}.${key}` : key;
@@ -32,7 +40,11 @@ function main() {
 
       const base = keysByLocale[i];
       const other = keysByLocale[j];
-      const missing = [...base.keys].filter((key) => !other.keys.has(key));
+      const missing = [...base.keys].filter((key) => {
+        if (other.keys.has(key)) return false;
+        const allowedLocales = ALLOWED_MISMATCHES[key];
+        return !allowedLocales || !allowedLocales.includes(other.locale);
+      });
 
       if (missing.length > 0) {
         hasMismatch = true;


### PR DESCRIPTION
## 관련 이슈

- close #이슈번호

## 작업 내용

- PR마다 ko/en 번역 키 불일치를 자동으로 검출하도록 check:i18n-keys를 jest CI 워크플로우(.github/workflows/jest.yml)에 차단형 스텝으로 추가했습니다.
- 하드코딩 한글 리터럴 검사(lint:i18n-literal)도 함께 연결했습니다. 다만 기존에 warning이 다수 남아 있어 참고용 로그만 남기고 PR을 막지는 않도록 continue-on-error로 처리했습니다.
- PostDetailBody 컴포넌트는 로케일별로 표현 방식이 달라(한국어는 고정 라벨, 영어는 ICU plural) ko/en 키가 의도적으로 비대칭입니다. 이 예외를 scripts/check-i18n-keys.js의 허용 목록(ALLOWED_MISMATCHES)으로 처리해 오탐을 막았습니다.
- 라우트 작업에서 새로운 정적 텍스트가 추가될 때(신규 페이지 생성이든 기존 페이지 수정이든 동일하게) 번역 작업 순서(네임스페이스 결정, t() 구현, ko/en 키 동시 작성, 로컬 검증)를 놓치지 않도록 plan-route 스킬에 번역 체크리스트를 추가했습니다. 라우트 작업을 시작하면 자동으로 _docs/plan.md에 이 항목들이 포함됩니다.

## 참고 사항

- lint:i18n-literal은 기존 하드코딩 한글 리터럴 131건이 아직 남아 있어 비차단으로 연결했습니다. 추후 정리가 완료되면 차단형으로 전환하는 것을 검토해야 합니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/스토리북/테스트 통과
- [x] 불필요한 코드/주석 제거